### PR TITLE
Fix dead touch under Bookworm Xwayland when FINGER mode is enabled.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,8 +108,12 @@ VESSEL_PARKED_SOG_KT=0.5
 # Filter stuck capacitive jitter (ghost touches) before navigation. Set false to disable.
 GHOST_TOUCH_FILTER=True
 
-# Waveshare capacitive DSI panel: use FINGER events for swipes/taps (not mouse).
-TOUCH_USE_FINGER_EVENTS=True
+# Touch event path for taps/swipes.
+# False (default): MOUSEBUTTON*/MOUSEMOTION — correct for Raspberry Pi OS Bookworm
+# with labwc/Wayland + Xwayland, which pointer-emulates touch and never sends FINGER*.
+# True: prefer SDL FINGER* when the stack actually delivers them (some capacitive DSI
+# setups). If True but only mouse events arrive, the app falls back to mouse automatically.
+TOUCH_USE_FINGER_EVENTS=False
 
 # Verbose touch logging for journalctl (leave off in normal use).
 #TOUCH_DEBUG=1

--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ This installs system packages, creates `flightscnr-venv/`, downloads UI assets (
 | Logs                   | `sudo journalctl -u flightscnr -f`                             |
 
 
+**Touch works in `evtest` / `i2cdetect` but taps do nothing in the app?** On Raspberry Pi OS Bookworm with labwc/Wayland, Xwayland usually delivers **mouse** events for the panel, not SDL `FINGER*` events. If `/etc/flightscnr.env` has `TOUCH_USE_FINGER_EVENTS=True`, taps are dropped:
+
+```bash
+sudo sed -i 's/^TOUCH_USE_FINGER_EVENTS=.*/TOUCH_USE_FINGER_EVENTS=False/' /etc/flightscnr.env
+sudo systemctl restart flightscnr
+```
+
+Current builds also fall back to the mouse path automatically when no `FINGER*` events arrive (see [issue #14](https://github.com/yashmulgaonkar/FlightScnr_Pi/issues/14)).
+
+
 
 
 #### 6. Configure

--- a/flightscnr/display/round_touch/gesture_handler.py
+++ b/flightscnr/display/round_touch/gesture_handler.py
@@ -11,9 +11,12 @@ Validated behaviour (Jul 2026):
   - Phantom 2nd contacts during swipe must NOT zoom or eat taps
 
 Architecture:
-  Swipes/taps use MOUSEBUTTON* + MOUSEMOTION (_USE_FINGER_EVENTS=False).
+  Swipes/taps default to MOUSEBUTTON* + MOUSEMOTION (Xwayland-safe).
+  TOUCH_USE_FINGER_EVENTS=True prefers FINGER* once a FINGER event is seen;
+  until then mouse events are still accepted (Bookworm labwc/Xwayland, issue #14).
   Pinch uses FINGERDOWN / FINGERMOTION / FINGERUP on the radar screen only.
-  The mouse button is the source of truth for single-finger gestures:
+  The mouse button is the source of truth for single-finger gestures when
+  use_finger_events() is False:
     - sync_pointer_down() on MOUSEBUTTONDOWN clears stale finger contacts
     - sync_pointer_up() on MOUSEBUTTONUP resets all finger tracking
   Event order per frame: pointer sync → input.handle_event → pinch.handle_event
@@ -38,7 +41,7 @@ def _debug_enabled() -> bool:
     return os.environ.get("TOUCH_DEBUG", "").strip().lower() in ("1", "true", "yes")
 
 # Bump when the frozen contract intentionally changes (see module docstring).
-GESTURE_LOGIC_VERSION = 1
+GESTURE_LOGIC_VERSION = 2
 
 
 class RadarGestureHandler:

--- a/flightscnr/display/round_touch/input_handler.py
+++ b/flightscnr/display/round_touch/input_handler.py
@@ -1,12 +1,22 @@
 """Touch swipe and tap detection (FlightScnr navigation).
 
 FROZEN — see gesture_handler.py and tests/test_gesture_handler.py.
-Swipes/taps use MOUSE events only (_USE_FINGER_EVENTS=False).
+
+Default path: MOUSEBUTTON* / MOUSEMOTION (works under Bookworm labwc/Xwayland,
+which pointer-emulates touch and never sends FINGER*).
+
+Optional TOUCH_USE_FINGER_EVENTS=True prefers FINGER* when the stack actually
+delivers them (some capacitive DSI + SDL paths). Until a FINGER event is seen,
+mouse events are still accepted so Xwayland installs are not dead (issue #14).
 """
 
+import logging
 import math
+import os
 
 import pygame
+
+logger = logging.getLogger("flightscnr.display")
 
 SWIPE_NONE = 0
 SWIPE_UP = 1
@@ -14,19 +24,53 @@ SWIPE_DOWN = 2
 SWIPE_LEFT = 3
 SWIPE_RIGHT = 4
 
-# Capacitive panels (Waveshare DSI) emit FINGER events; resistive panels use mouse.
-def _use_finger_events() -> bool:
-    import os
 
+def _env_prefer_finger_events() -> bool:
     raw = os.environ.get("TOUCH_USE_FINGER_EVENTS", "false").strip().lower()
     return raw in ("1", "true", "yes", "on")
 
 
-_USE_FINGER_EVENTS = _use_finger_events()
+# Configured preference from env (True = prefer FINGER* when available).
+_USE_FINGER_EVENTS = _env_prefer_finger_events()
+# Latched once any FINGER* event arrives this process.
+_finger_events_seen = False
+_logged_mouse_fallback = False
+
+
+def prefer_finger_events() -> bool:
+    """True when env asks for FINGER*-based single-touch handling."""
+    return _USE_FINGER_EVENTS
 
 
 def use_finger_events() -> bool:
-    return _USE_FINGER_EVENTS
+    """True when single-touch should use the FINGER* path right now.
+
+    Stays False until a FINGER event is observed, even if env prefers fingers,
+    so Bookworm + Xwayland (mouse-only) keeps working with a True env value.
+    """
+    return _USE_FINGER_EVENTS and _finger_events_seen
+
+
+def _note_finger_event() -> None:
+    global _finger_events_seen
+    if not _finger_events_seen:
+        _finger_events_seen = True
+        if _USE_FINGER_EVENTS:
+            logger.info(
+                "Touch: FINGER events detected — using finger path for taps/swipes"
+            )
+
+
+def _note_mouse_fallback() -> None:
+    global _logged_mouse_fallback
+    if _logged_mouse_fallback or not _USE_FINGER_EVENTS or _finger_events_seen:
+        return
+    _logged_mouse_fallback = True
+    logger.info(
+        "Touch: mouse events without FINGER* (typical under Xwayland) — "
+        "using mouse path; set TOUCH_USE_FINGER_EVENTS=False in /etc/flightscnr.env "
+        "to silence this (GitHub issue #14)"
+    )
 
 
 def _gesture_threshold_px() -> int:
@@ -149,13 +193,18 @@ class TouchInput:
         self._clear_pending()
 
     def handle_event(self, event: pygame.event.Event):
-        if _USE_FINGER_EVENTS and event.type in (
+        if event.type in (pygame.FINGERDOWN, pygame.FINGERMOTION, pygame.FINGERUP):
+            _note_finger_event()
+
+        # Drop redundant mouse down/motion only after FINGER* has proven available.
+        # Under Xwayland, FINGER* never arrives — keep mouse so taps are not dead.
+        if use_finger_events() and event.type in (
             pygame.MOUSEBUTTONDOWN,
             pygame.MOUSEMOTION,
         ):
             return
 
-        if _USE_FINGER_EVENTS and event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+        if use_finger_events() and event.type == pygame.MOUSEBUTTONUP and event.button == 1:
             # Waveshare DSI reports both FINGER* and MOUSE*; release is often mouse-only.
             if self._start is not None:
                 sx, sy = self._start
@@ -166,7 +215,7 @@ class TouchInput:
                 self._finish_pointer(sx, sy, ex, ey)
             return
 
-        if event.type in (pygame.FINGERDOWN, pygame.FINGERUP) and not _USE_FINGER_EVENTS:
+        if event.type in (pygame.FINGERDOWN, pygame.FINGERUP) and not prefer_finger_events():
             return
 
         if event.type == pygame.FINGERDOWN:
@@ -206,6 +255,7 @@ class TouchInput:
             return
 
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            _note_mouse_fallback()
             self._clear_pending()
             self._start = _logical_pos(event.pos)
             self._drag_end = self._start

--- a/flightscnr/tests/test_gesture_handler.py
+++ b/flightscnr/tests/test_gesture_handler.py
@@ -244,11 +244,16 @@ class TestRadarGestureHandler(unittest.TestCase):
 
 
 class TestFingerEventMode(unittest.TestCase):
+    def setUp(self):
+        input_handler._finger_events_seen = False
+        input_handler._logged_mouse_fallback = False
+
     def test_finger_swipe_with_mouse_release_fallback(self):
         touch = TouchInput()
         surface = _surface()
         with _coord_patches(surface), patch.object(input_handler, "_USE_FINGER_EVENTS", True):
             touch.handle_event(_finger_event(pygame.FINGERDOWN, fid=3, x=100 / 720, y=100 / 720))
+            self.assertTrue(input_handler.use_finger_events())
             touch.handle_event(
                 _finger_event(pygame.FINGERMOTION, fid=3, x=200 / 720, y=100 / 720)
             )
@@ -256,6 +261,30 @@ class TestFingerEventMode(unittest.TestCase):
             gesture = touch.consume_gesture()
         self.assertEqual(gesture[0], "swipe")
         self.assertEqual(gesture[1], SWIPE_RIGHT)
+
+    def test_xwayland_mouse_works_when_finger_env_true(self):
+        """Issue #14: env True but stack only delivers mouse — taps must still work."""
+        touch = TouchInput()
+        surface = _surface()
+        with _coord_patches(surface), patch.object(input_handler, "_USE_FINGER_EVENTS", True):
+            self.assertFalse(input_handler.use_finger_events())
+            touch.handle_event(_mouse_down(100, 100))
+            touch.handle_event(_mouse_up(110, 110))
+            gesture = touch.consume_gesture()
+        self.assertEqual(gesture[0], "tap")
+        self.assertEqual(gesture[1], (110, 110))
+        self.assertFalse(input_handler.use_finger_events())
+
+    def test_finger_mode_ignores_mouse_down_after_finger_seen(self):
+        touch = TouchInput()
+        surface = _surface()
+        with _coord_patches(surface), patch.object(input_handler, "_USE_FINGER_EVENTS", True):
+            touch.handle_event(_finger_event(pygame.FINGERDOWN, fid=1, x=100 / 720, y=100 / 720))
+            touch.handle_event(_mouse_down(200, 200))  # must not relocate / second-start
+            touch.handle_event(_finger_event(pygame.FINGERUP, fid=1, x=100 / 720, y=100 / 720))
+            gesture = touch.consume_gesture()
+        self.assertEqual(gesture[0], "tap")
+        self.assertEqual(gesture[1], (100, 100))
 
     def test_finger_mode_pinch_after_second_finger(self):
         handler = RadarGestureHandler(TouchInput(), PinchZoom())

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -363,6 +363,16 @@ setup_config_h() {
 setup_env_file() {
     if [ -f "$ENV_DEST" ]; then
         log_ok "$ENV_DEST already exists — keeping current configuration"
+        # Bookworm labwc/Xwayland pointer-emulates touch (MOUSE* only). An old
+        # TOUCH_USE_FINGER_EVENTS=True install silently drops every tap (#14).
+        if grep -qE '^[[:space:]]*TOUCH_USE_FINGER_EVENTS=(True|true|1|yes|on)[[:space:]]*$' "$ENV_DEST"; then
+            if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+                sed -i 's/^[[:space:]]*TOUCH_USE_FINGER_EVENTS=.*/TOUCH_USE_FINGER_EVENTS=False/' "$ENV_DEST"
+                log_ok "Set TOUCH_USE_FINGER_EVENTS=False for Wayland/Xwayland touch (issue #14)"
+            else
+                log_warn "TOUCH_USE_FINGER_EVENTS is True — if taps do nothing under Xwayland, set it False in $ENV_DEST"
+            fi
+        fi
     else
         log_step "Creating $ENV_DEST"
         if [ -f "$REPO_ROOT/.env" ]; then


### PR DESCRIPTION
Accept mouse events until FINGER* arrives, default the env to False, and document the workaround for issue #14.