### PR TITLE
Fix portal update stuck at 'Update in progress' (KillMode mixed -> pr…

### DIFF
--- a/flightscnr/setup/flightscnr.service
+++ b/flightscnr/setup/flightscnr.service
@@ -25,7 +25,7 @@ ExecStart=__REPO_DIR__/flightscnr-venv/bin/python3 __REPO_DIR__/flightscnr/fligh
 Restart=always
 RestartSec=10
 TimeoutStopSec=15
-KillMode=mixed
+KillMode=process
 User=root
 Group=root
 


### PR DESCRIPTION
## Problem

Triggering an update from the web portal shows "Update in progress…" indefinitely. The update itself completes successfully (git pull, dependency sync, and version bump all work correctly), but the portal's status never reflects that — permanently blocking further use of the portal-triggered update mechanism.

## Root cause

Self-referential process kill, not a missing status write:

1. The portal launches `portal-update.sh` via `subprocess.Popen(..., start_new_session=True)`. This detaches it from the Flask process's process *group*, but it remains a member of `flightscnr.service`'s systemd **cgroup**.
2. `portal-update.sh` writes `state: "running"` to `update-status.json`, then runs `install-pi.sh update`, which completes successfully.
3. At the end, `install-pi.sh`'s `start_service()` calls `systemctl restart flightscnr` **synchronously, from inside the very cgroup being restarted.**
4. With `KillMode=mixed`, systemd sends `SIGTERM` only to the main PID immediately, but gives other cgroup members (including the update script and the `systemctl restart` call itself) up to `TimeoutStopSec=15` before force-killing stragglers.
5. Since `systemctl restart` blocks until its own cgroup is empty — and that cgroup includes the shell running `systemctl restart` — it can't exit gracefully. After 15s, systemd `SIGKILL`s the entire remaining tree, including `portal-update.sh`.
6. `SIGKILL` can't be trapped, so `portal-update.sh`'s `trap cleanup EXIT` (the only code that writes `state: "success"` and removes `update.lock`) never runs.
7. `update-status.json` is left frozen at `state: "running"` forever, even though the new version is already running.

## Fix

One-line change: `KillMode=mixed` → `KillMode=process` in `flightscnr.service`. With `KillMode=process`, systemd only ever signals the unit's main PID on stop/restart; background stragglers left in the cgroup (like the update script finishing its status write) are left alone to exit naturally instead of being force-killed by the restart's timeout sweep.

## Testing

Tested on a Pi 4B: after applying the fix, triggering an update correctly transitions update-status.json from running to a resolved state, rather than hanging indefinitely.

## Workaround (for anyone hitting this before the fix lands)

```bash
sudo rm -f /var/lib/flightscnr/update.lock
echo '{"state": "success", "message": "Manually cleared after self-kill during restart."}' | sudo tee /var/lib/flightscnr/update-status.json
```