### PR TITLE
Respect off-hours dim_percent on radar screen (only clock mode should force day brightness)

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -737,10 +737,14 @@ class RoundTouchDisplay:
         # Display-off mode: temporary wake after touch keeps daytime brightness.
         if pct == 0 and time.time() < self._off_hours_wake_until:
             pct = day_pct
-        # Off-hours clock mode: while the user is on radar (or other non-clock
-        # screens), restore their normal daytime brightness so traffic is readable.
+        # Legacy off-hours "clock" mode is always full daytime brightness (even
+        # on the clock screen itself). While on radar (or other non-clock
+        # screens) in that mode, restore daytime brightness so traffic is
+        # readable. Dim mode already has its own configured dim_percent that
+        # should apply uniformly across all screens, radar included.
         elif (
             off_hours.in_off_hours()
+            and off_hours.prefs().get("mode") == "clock"
             and self.screen
             not in (SCREEN_CLOCK, SCREEN_CLOCK_SETTINGS, SCREEN_FORECAST)
         ):


### PR DESCRIPTION
## Problem

During off-hours "dim" mode, switching from the clock screen to the radar screen jumps the backlight to full daytime brightness instead of respecting the configured `dim_percent`. Brightness only returns to the correct dim level when navigating back to the clock screen. This happens regardless of whether "show clock during off-hours" is enabled — confirmed by testing with that option both on and off.

Previous releases (verified against `2026.7.21.3`) did not have this problem; radar correctly displayed at the configured dim brightness during off-hours.

## Root cause

Regression introduced in the commit that made radar reachable during off-hours clock mode (fixing #18). `_apply_brightness()` in `app.py` added this override:

```python
elif (
    off_hours.in_off_hours()
    and self.screen not in (SCREEN_CLOCK, SCREEN_CLOCK_SETTINGS, SCREEN_FORECAST)
):
    pct = day_pct
```

The comment describes this as restoring "daytime brightness so traffic is readable" while in off-hours **clock mode** specifically — but the condition only checks `in_off_hours()`, not the actual `mode` setting. So it fires for **every** off-hours mode, including plain "dim" mode, which has its own explicit `dim_percent` that's meant to apply uniformly across all screens (and did, prior to this regression).

The legacy `mode == "clock"` case genuinely is always full daytime brightness by design (see `off_hours.effective_brightness_percent()` — `"Legacy: full day brightness while on clock."`), so restoring daytime brightness on radar in that specific mode is consistent. But "dim" mode has no such always-bright behavior anywhere else, and the override shouldn't apply to it.

## Fix

Scope the override to legacy clock mode only:

```python
elif (
    off_hours.in_off_hours()
    and off_hours.prefs().get("mode") == "clock"
    and self.screen not in (SCREEN_CLOCK, SCREEN_CLOCK_SETTINGS, SCREEN_FORECAST)
):
    pct = day_pct
```

Now:
- **`mode == "clock"`**: radar still gets daytime brightness while navigated to (original intent preserved, traffic stays readable in this always-bright mode)
- **`mode == "dim"`**: radar respects the configured `dim_percent` on every screen, same as before the regression

## Testing

Reproduced the bug on a Pi 4B: with off-hours mode set to "dim" and a custom dim level, navigating clock → radar jumped to full daytime brightness; navigating back to clock correctly returned to the dim level. Applied the fix and confirmed radar now stays at the configured dim brightness in "dim" mode, while "clock" mode continues to brighten radar as intended.