### PR TITLE
Altitude filter settings

### DIFF
--- a/flightscnr/config.py
+++ b/flightscnr/config.py
@@ -305,14 +305,19 @@ NIGHT_START = os.environ.get("NIGHT_START", "22:00")
 NIGHT_END = os.environ.get("NIGHT_END", "06:00")
 
 # --- Flight filtering (altitude in feet) ---
-MAX_ALTITUDE_FT = 100000
+#MAX_ALTITUDE_FT = 100000
+_raw_max_alt = os.environ.get("MAX_HEIGHT", os.environ.get("MAX_ALTITUDE", "50000"))
+MAX_ALTITUDE_FT = int(_raw_max_alt)
+MAX_HEIGHT = MAX_ALTITUDE_FT  # alias used in .env / UI wording
+
+
 _raw_min_alt = os.environ.get("MIN_HEIGHT", os.environ.get("MIN_ALTITUDE", "0"))
 MIN_ALTITUDE = int(_raw_min_alt)
 MIN_HEIGHT = MIN_ALTITUDE  # alias used in .env / UI wording
 
 
 def passes_altitude_filter(alt_ft) -> bool:
-    """True if aircraft altitude is at or above MIN_HEIGHT and within max."""
+    """True if aircraft altitude is at or above MIN_HEIGHT and below MAX_HEIGHT."""
     if alt_ft is None:
         return MIN_ALTITUDE <= 0
     try:
@@ -320,6 +325,7 @@ def passes_altitude_filter(alt_ft) -> bool:
     except (TypeError, ValueError):
         return MIN_ALTITUDE <= 0
     return MIN_ALTITUDE <= alt < MAX_ALTITUDE_FT
+
 JOURNEY_CODE_SELECTED = _require("JOURNEY_CODE_SELECTED")
 STATS_LOG_DAYS = int(os.environ.get("STATS_LOG_DAYS", "0"))
 _raw_filler = os.environ.get("JOURNEY_BLANK_FILLER", "").strip()

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -560,6 +560,8 @@ class RoundTouchDisplay:
             self._begin_map_pan()
         elif action == "min_height":
             settings.cycle_min_height()
+        elif action == "max_height":
+            settings.cycle_max_height()
         elif action == "sweep":
             settings.toggle_sweep_line()
         elif action == "precipitation":

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -47,6 +47,7 @@ DISPLAY_ACTIONS = (
 OPTIONS_ACTIONS = (
     "traffic",
     "min_height",
+    "max_height",
     "map_style",
     "vfr_opacity",
     "precipitation",
@@ -418,6 +419,7 @@ def _options_row_labels() -> list[str]:
     return [
         f"Traffic: {settings.traffic_mode_label()}",
         f"Min height: {settings.min_height_ft()} ft",
+        f"Max height: {settings.max_height_ft()} ft",
         f"Map: {settings.map_style_label()}",
         "",  # VFR opacity slider
         f"Precipitation: {precip}",

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -14,7 +14,8 @@ _settings_mtime: float | None = None
 # True when _state matches disk. Slider drags set this False until persist.
 _disk_synced = True
 
-MIN_HEIGHT_OPTIONS = (0, 500, 1000, 1500)
+MIN_HEIGHT_OPTIONS = (0, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000)
+MAX_HEIGHT_OPTIONS = (1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 6000, 7000, 8000, 9000, 10000, 12000, 14000, 16000, 18000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 100000)
 TRAFFIC_MODES = ("aircraft", "marine", "both")
 MAP_STYLES = ("dark", "light", "vfr")
 
@@ -50,6 +51,7 @@ _defaults = {
     "clock_12hr": True,
     "auto_timezone": True,
     "min_height_ft": 1000,
+    "max_height_ft": 50000,
     "auto_idle_clock": True,
     "flight_detail_timeout_s": 20,
     "clock_timeout_s": 10,
@@ -94,15 +96,34 @@ def _env_min_height() -> int:
         return 1000
 
 
+def _snap_max_height(value) -> int:
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return 50000
+    if v in MAX_HEIGHT_OPTIONS:
+        return v
+    return min(MAX_HEIGHT_OPTIONS, key=lambda opt: abs(opt - v))
+
+
+def _env_max_height() -> int:
+    try:
+        from config import MAX_HEIGHT
+        return _snap_max_height(MAX_HEIGHT)
+    except ImportError:
+        return 50000
+
+
 def _seed_from_env(state: dict) -> None:
     """First-run defaults from /etc/flightscnr.env (not applied after settings are saved)."""
     try:
-        from config import DISTANCE_UNITS, MIN_HEIGHT, SEARCH_RADIUS_NM
+        from config import DISTANCE_UNITS, MIN_HEIGHT, MAX_HEIGHT, SEARCH_RADIUS_NM
         from display.round_touch import map_bg, scale
 
         state["distance_units"] = "mi" if DISTANCE_UNITS.strip().lower() == "imperial" else "km"
         state["scale_index"] = scale.index_for_radius_nm(SEARCH_RADIUS_NM)
         state["min_height_ft"] = _snap_min_height(MIN_HEIGHT)
+        state["max_height_ft"] = _snap_max_height(MAX_HEIGHT)
         env_style = map_bg.normalize_map_style(os.environ.get("RADAR_MAP_PROVIDER", "dark"))
         # UI only cycles dark/light/vfr; map legacy osm to dark for first-run seed.
         state["map_style"] = env_style if env_style in MAP_STYLES else "dark"
@@ -153,6 +174,11 @@ def _load():
         migrated = True
     else:
         state["min_height_ft"] = _snap_min_height(state["min_height_ft"])
+    if "max_height_ft" not in data:
+        state["max_height_ft"] = _env_max_height()
+        migrated = True
+    else:
+        state["max_height_ft"] = _snap_max_height(state["max_height_ft"])
     if "distance_miles" in data and "distance_units" not in data:
         state["distance_units"] = "mi" if data.get("distance_miles") else "km"
         migrated = True
@@ -229,6 +255,7 @@ def _settings_snapshot(state: dict) -> tuple:
         state.get("show_sweep"),
         state.get("show_precipitation"),
         state.get("min_height_ft"),
+        state.get("max_height_ft"),
         state.get("brightness_percent"),
         state.get("auto_idle_clock"),
         state.get("flight_detail_timeout_s"),
@@ -298,6 +325,7 @@ def reload() -> bool:
         _settings_mtime = None
     _disk_synced = True
     _sync_config_min_height()
+    _sync_config_max_height()
     # Re-apply runtime palette when theme changes are saved externally
     # (e.g. from the web portal process).
     apply_theme_colors()
@@ -334,6 +362,38 @@ def set_min_height_ft(value: int):
 
 
 _sync_config_min_height()
+
+
+def _sync_config_max_height():
+    try:
+        import config
+        h = max_height_ft()
+        config.MAX_ALTITUDE_FT = h
+        config.MAX_HEIGHT = h
+    except ImportError:
+        pass
+
+
+def max_height_ft() -> int:
+    return _snap_max_height(_state.get("max_height_ft", 50000))
+
+
+def cycle_max_height():
+    opts = MAX_HEIGHT_OPTIONS
+    current = max_height_ft()
+    idx = opts.index(current) if current in opts else 0
+    _state["max_height_ft"] = opts[(idx + 1) % len(opts)]
+    _sync_config_max_height()
+    _save(_state)
+
+
+def set_max_height_ft(value: int):
+    _state["max_height_ft"] = _snap_max_height(value)
+    _sync_config_max_height()
+    _save(_state)
+
+
+_sync_config_max_height()
 
 
 def brightness_percent():

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+from logging import config
+
 from flask import Flask, render_template, jsonify, send_from_directory, request, redirect
 import json
 import os
@@ -10,6 +12,7 @@ if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 
 from config import (
+    MIN_ALTITUDE,
     WEB_PORT,
     format_location_home,
     location_configured,
@@ -621,6 +624,7 @@ def radar_json():
             "range_value": scale.format_display_value(idx, units),
             "range_presets_mi": list(scale.PRESET_STATUTE_MILES),
             "min_height_ft": settings.min_height_ft(),
+            "max_height_ft": settings.max_height_ft(),            
             "theme_index": settings.theme_index(),
             "theme_options": list(color_presets.THEME_NAMES),
             "show_compass_rose": settings.show_compass_rose(),
@@ -665,6 +669,8 @@ def radar_save():
         rainviewer_overlay.request_overlay()
     if "min_height_ft" in data:
         settings.set_min_height_ft(int(data.get("min_height_ft")))
+    if "max_height_ft" in data:
+        settings.set_max_height_ft(int(data.get("max_height_ft")))
     if "theme_index" in data:
         settings.set_theme_index(int(data.get("theme_index")))
     if "show_compass_rose" in data:

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -106,6 +106,42 @@
                 <option value="500">500</option>
                 <option value="1000">1000</option>
                 <option value="1500">1500</option>
+                <option value="2000">2000</option>
+                <option value="2500">2500</option>
+                <option value="3000">3000</option>
+                <option value="3500">3500</option>
+                <option value="4000">4000</option>
+                <option value="4500">4500</option>
+                <option value="5000">5000</option>
+            </select>
+            <label for="max_height">Max altitude ceiling (ft)</label>
+            <select id="max_height">
+                <option value="1000">1000</option>
+                <option value="1500">1500</option>
+                <option value="2000">2000</option>
+                <option value="2500">2500</option>
+                <option value="3000">3000</option>                
+                <option value="3500">3500</option>
+                <option value="4000">4000</option>                
+                <option value="4500">4500</option>                
+                <option value="5000">5000</option>                
+                <option value="6000">6000</option>                
+                <option value="7000">7000</option>                
+                <option value="8000">8000</option>                
+                <option value="9000">9000</option>                
+                <option value="10000">10000</option>                
+                <option value="12000">12000</option>                  
+                <option value="14000">14000</option>                  
+                <option value="16000">16000</option>                  
+                <option value="18000">18000</option>                
+                <option value="20000">20000</option>                
+                <option value="25000">25000</option>                
+                <option value="30000">30000</option>                
+                <option value="35000">35000</option>                
+                <option value="40000">40000</option>                
+                <option value="45000">45000</option>                
+                <option value="50000">50000</option>                
+                <option value="100000">100000</option>                
             </select>
             <label for="radar_theme">Color theme</label>
             <select id="radar_theme"></select>
@@ -562,6 +598,7 @@ async function loadAll() {
         updateRangeHint(r.range_presets_mi);
         refreshRangeInput();
         $("min_height").value = String(r.min_height_ft ?? 1000);
+        $("max_height").value = String(r.max_height_ft ?? 50000);
         const theme = $("radar_theme");
         theme.innerHTML = "";
         (r.theme_options || []).forEach((name, idx) => {
@@ -666,6 +703,7 @@ async function saveRadar() {
                 distance_units: $("dist_units").value,
                 range_value: $("range_value").value.trim(),
                 min_height_ft: Number($("min_height").value),
+                max_height_ft: Number($("max_height").value),                
                 theme_index: Number($("radar_theme").value),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
@@ -713,6 +751,7 @@ async function saveAndReloadSettings() {
                 distance_units: $("dist_units").value,
                 range_value: $("range_value").value.trim(),
                 min_height_ft: Number($("min_height").value),
+                max_height_ft: Number($("max_height").value),
                 theme_index: Number($("radar_theme").value),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,


### PR DESCRIPTION
Added some more altitude values for Minimum Altitude. 

I've also add a 'Maximum altitude ceiling' to the web interface and the display info screen. 

This should allow you to now see only planes below that maximum altitude and above the minimum. 

I live near a small airport so it's nice to be able to clear the screen of the high altitude flights.
