### PR TITLE
Fix UnboundLocalError on Settings "range" row (rainviewer_overlay local import)

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -566,8 +566,6 @@ class RoundTouchDisplay:
             settings.toggle_sweep_line()
         elif action == "precipitation":
             settings.toggle_show_precipitation()
-            from display.round_touch import rainviewer_overlay
-
             rainviewer_overlay.invalidate()
             rainviewer_overlay.request_overlay()
         elif action == "map_style":


### PR DESCRIPTION
Fixes #23

## Problem
Tapping the Settings **"range"** row crashes the display loop with:
```
UnboundLocalError: cannot access local variable 'rainviewer_overlay' where it is not associated with a value
```

(Note I currently do not have the display and am using PiConnect to test, but I think this bug will manifest itself regardless)

## Cause
`_apply_display_row()` in `flightscnr/display/round_touch/app.py` imports `rainviewer_overlay` **locally** inside the `"precipitation"` branch. Python treats a name imported (assigned) anywhere in a function as function-local for the whole body — so the earlier `"range"` branch, which uses `rainviewer_overlay.request_overlay()`, hits `UnboundLocalError` before that import line runs. The module-level import at the top of `app.py` already provides the name.

## Fix
Delete the redundant function-local import; both branches now use the module-level import. One line.

## Verification
- `symtable` confirms `rainviewer_overlay` is now **global** (not local) within `_apply_display_row` — the exact binding that caused the crash is gone.
- `app.py` byte-compiles.

Reproduced and confirmed on `main` @ e19ba71 (2026.7.22.4).
