### PR TITLE
Add toggle for showing plane tag (callsign/type/altitude) on main screen

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -558,6 +558,8 @@ class RoundTouchDisplay:
             self._begin_facing_calibrate()
         elif action == "recenter":
             self._begin_map_pan()
+        elif action == "aircraft_tag":
+            settings.toggle_show_aircraft_tag()
         elif action == "min_height":
             settings.cycle_min_height()
         elif action == "max_height":

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -46,6 +46,7 @@ DISPLAY_ACTIONS = (
 )
 OPTIONS_ACTIONS = (
     "traffic",
+    "aircraft_tag",
     "min_height",
     "max_height",
     "map_style",
@@ -414,10 +415,12 @@ def _display_row_labels() -> list[str]:
 
 
 def _options_row_labels() -> list[str]:
+    aircraft_tag = "on" if settings.show_aircraft_tag() else "off"
     precip = "on" if settings.show_precipitation() else "off"
     idle = "on" if settings.auto_idle_clock_enabled() else "off"
     return [
         f"Traffic: {settings.traffic_mode_label()}",
+        f"Aircraft info: {aircraft_tag}",
         f"Min height: {settings.min_height_ft()} ft",
         f"Max height: {settings.max_height_ft()} ft",
         f"Map: {settings.map_style_label()}",

--- a/flightscnr/display/round_touch/screens/radar.py
+++ b/flightscnr/display/round_touch/screens/radar.py
@@ -54,6 +54,7 @@ def _backdrop_cache_key(*, pan_mode: bool, calibrate: bool):
         id(overlay) if overlay is not None else 0,
         settings.show_compass_rose(),
         settings.show_range_rings(),
+        settings.show_aircraft_tag(),
         settings.theme_index(),
         settings.theme_custom(),
         settings.theme_rgb(),
@@ -296,40 +297,41 @@ def _draw_aircraft_tag(surface, x, y, flight):
         _draw_vessel_tag(surface, x, y, flight)
         return
 
-    block_h, offsets, main_font, sub_font = _tag_block_metrics()
-    try:
-        from utilities.airline_branding import display_flight_id_for_flight
-        callsign = display_flight_id_for_flight(flight)
-    except ImportError:
-        callsign = flight.get("callsign") or "—"
-    plane_type = flight.get("plane") or ""
-    alt = aircraft.format_altitude(flight.get("altitude"))
-    alt_color = aircraft.altitude_tag_color(flight.get("vertical_speed"))
+    if settings.show_aircraft_tag():
+        block_h, offsets, main_font, sub_font = _tag_block_metrics()
+        try:
+            from utilities.airline_branding import display_flight_id_for_flight
+            callsign = display_flight_id_for_flight(flight)
+        except ImportError:
+            callsign = flight.get("callsign") or "—"
+        plane_type = flight.get("plane") or ""
+        alt = aircraft.format_altitude(flight.get("altitude"))
+        alt_color = aircraft.altitude_tag_color(flight.get("vertical_speed"))
 
-    ly = y - block_h // 2
-    tag_on_right = x < theme.CENTER_X
-    symbol_half = theme.AIRCRAFT_ICON_RADIUS
+        ly = y - block_h // 2
+        tag_on_right = x < theme.CENTER_X
+        symbol_half = theme.AIRCRAFT_ICON_RADIUS
 
-    if tag_on_right:
-        anchor_x = min(x + symbol_half + theme.AIRCRAFT_LABEL_GAP, theme.CENTER_X + theme.VISIBLE_RADIUS - theme.s(20))
-        align = "left"
-    else:
-        anchor_x = max(x - symbol_half - theme.AIRCRAFT_LABEL_GAP, theme.CENTER_X - theme.VISIBLE_RADIUS + theme.s(20))
-        align = "right"
-
-    lines = [
-        (callsign, _overlay_color_for_basemap(theme.GRID), main_font, offsets[0]),
-        (plane_type, _overlay_color_for_basemap(theme.TAG_TYPE), sub_font, offsets[1]),
-        (alt, _overlay_color_for_basemap(alt_color), sub_font, offsets[2]),
-    ]
-    for i, (text, color, font, row_y) in enumerate(lines):
-        if not text or text == "—" and i == 1:
-            continue
-        rendered = font.render(text, True, color)
-        if align == "left":
-            surface.blit(rendered, (anchor_x, ly + row_y))
+        if tag_on_right:
+            anchor_x = min(x + symbol_half + theme.AIRCRAFT_LABEL_GAP, theme.CENTER_X + theme.VISIBLE_RADIUS - theme.s(20))
+            align = "left"
         else:
-            surface.blit(rendered, rendered.get_rect(topright=(anchor_x, ly + row_y)))
+            anchor_x = max(x - symbol_half - theme.AIRCRAFT_LABEL_GAP, theme.CENTER_X - theme.VISIBLE_RADIUS + theme.s(20))
+            align = "right"
+
+        lines = [
+            (callsign, _overlay_color_for_basemap(theme.GRID), main_font, offsets[0]),
+            (plane_type, _overlay_color_for_basemap(theme.TAG_TYPE), sub_font, offsets[1]),
+            (alt, _overlay_color_for_basemap(alt_color), sub_font, offsets[2]),
+        ]
+        for i, (text, color, font, row_y) in enumerate(lines):
+            if not text or text == "—" and i == 1:
+                continue
+            rendered = font.render(text, True, color)
+            if align == "left":
+                surface.blit(rendered, (anchor_x, ly + row_y))
+            else:
+                surface.blit(rendered, rendered.get_rect(topright=(anchor_x, ly + row_y)))
 
 
 def _visible_flights(flights):

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -48,6 +48,7 @@ _defaults = {
     "distance_units": "km",
     "show_compass_rose": True,
     "show_range_rings": True,
+    "show_aircraft_tag": True,
     # Real-world direction at the top of the screen (0=north-up).
     "facing_deg": 0.0,
     "show_sweep": True,
@@ -283,6 +284,7 @@ def _settings_snapshot(state: dict) -> tuple:
         tuple(color_presets.normalize_rgb(state.get("custom_theme_rgb"))),
         state.get("show_compass_rose"),
         state.get("show_range_rings"),
+        state.get("show_aircraft_tag"),
         _normalize_facing(state.get("facing_deg", 0)),
         state.get("show_sweep"),
         state.get("show_precipitation"),
@@ -658,6 +660,20 @@ def toggle_range_rings():
 
 def set_show_range_rings(enabled: bool):
     _state["show_range_rings"] = bool(enabled)
+    _save(_state)
+
+
+def show_aircraft_tag() -> bool:
+    return bool(_state.get("show_aircraft_tag", True))
+
+
+def toggle_show_aircraft_tag():
+    _state["show_aircraft_tag"] = not show_aircraft_tag()
+    _save(_state)
+
+
+def set_show_aircraft_tag(enabled: bool):
+    _state["show_aircraft_tag"] = bool(enabled)
     _save(_state)
 
 

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -626,6 +626,7 @@ def radar_json():
             "theme_options": list(color_presets.THEME_NAMES),
             "show_compass_rose": settings.show_compass_rose(),
             "show_range_rings": settings.show_range_rings(),
+            "show_aircraft_tag": settings.show_aircraft_tag(),
             "facing_deg": settings.facing_deg(),
             "show_sweep_line": settings.show_sweep_line(),
             "show_precipitation": settings.show_precipitation(),
@@ -674,6 +675,8 @@ def radar_save():
         settings.set_show_compass_rose(bool(data.get("show_compass_rose")))
     if "show_range_rings" in data:
         settings.set_show_range_rings(bool(data.get("show_range_rings")))
+    if "show_aircraft_tag" in data:
+        settings.set_show_aircraft_tag(bool(data.get("show_aircraft_tag")))
     if "facing_deg" in data:
         settings.set_facing_deg(data.get("facing_deg"))
     if "show_sweep_line" in data:

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -164,6 +164,10 @@
                 <label for="show_range_rings">Show range rings</label>
                 <span class="switch"><input id="show_range_rings" type="checkbox"><span class="track"></span></span>
             </div>
+            <div class="chk">
+                <label for="show_aircraft_tag">Show aircraft information</label>
+                <span class="switch"><input id="show_aircraft_tag" type="checkbox"><span class="track"></span></span>
+            </div>
             <label for="facing_deg">Facing direction (degrees)</label>
             <input id="facing_deg" type="number" min="0" max="359" step="1" value="0">
             <p class="hint">Real-world direction at the top of the screen (0 = north, 90 = east, 180 = south, 270 = west). You can also set this on the device under Settings → Display → Facing.</p>
@@ -616,6 +620,7 @@ async function loadAll() {
         }
         $("show_compass").checked = !!r.show_compass_rose;
         if ($("show_range_rings")) $("show_range_rings").checked = r.show_range_rings !== false;
+        $("show_aircraft_tag").checked = !!r.show_aircraft_tag;
         $("facing_deg").value = String(Math.round(Number(r.facing_deg) || 0) % 360);
         $("show_sweep").checked = !!r.show_sweep_line;
         $("show_precip").checked = r.show_precipitation !== false;
@@ -708,6 +713,7 @@ async function saveRadar() {
                 theme_index: Number($("radar_theme").value),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
+                show_aircraft_tag: $("show_aircraft_tag").checked,
                 facing_deg: Number($("facing_deg").value),
                 show_sweep_line: $("show_sweep").checked,
                 show_precipitation: $("show_precip").checked,
@@ -756,6 +762,7 @@ async function saveAndReloadSettings() {
                 theme_index: Number($("radar_theme").value),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
+                show_aircraft_tag: $("show_aircraft_tag").checked,
                 facing_deg: Number($("facing_deg").value),
                 show_sweep_line: $("show_sweep").checked,
                 show_precipitation: $("show_precip").checked,


### PR DESCRIPTION
An option on the web interface (Show aircraft information) and Options screen ( Aircraft info) to toggle the plane tag/info from showing.

If the screen is busy with planes things just overdraw each other. By hiding the tag it just clears things up, and you can then press the plane to see its details.