### PR TITLE
Fix Bluetooth ATC audio when pactl is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Portal preferences are stored on the Pi in `/var/lib/flightscnr/` and apply with
 | **[AirLabs](https://airlabs.co/signup)**                               | Optional                 | Scheduled departure info when a tracked flight is not yet airborne                                                                                |
 | **[FlightAware AeroAPI](https://www.flightaware.com/commercial/aeroapi/)** | Optional             | Route fallback when FR24/AirLabs lack origin/destination (capped monthly spend — **not** a live radar feed)                                         |
 | **[OpenSky Network](https://opensky-network.org/)**                    | Optional                 | Further route fallback when FR24/AirLabs/FlightAware lack origin/destination; derived from position history (destination often empty while airborne) |
-| **[LiveATC](https://www.liveatc.net/)**                                | Optional                 | Manual ATC audio to a USB or Bluetooth speaker via `mpv` (portal / Settings → ATC). Pair Bluetooth on the web portal; on-screen ATC offers quick reconnect. Install: `sudo apt install mpv bluez`. |
+| **[LiveATC](https://www.liveatc.net/)**                                | Optional                 | Manual ATC audio to a USB or Bluetooth speaker via `mpv` (portal / Settings → ATC). Pair Bluetooth on the web portal; on-screen ATC offers quick reconnect. Install: `sudo apt install mpv bluez libspa-0.2-bluetooth pulseaudio-utils`. |
 
 
 API responses are **cached** (e.g. FR24 feed ~90s, flight details ~30 min, weather ~1 hr) to reduce quota use during 24/7 operation. Offline databases (`airports.json`, `airlines.json`, `icao_types.json`) download on first run.

--- a/flightscnr/tests/test_bluetooth_audio.py
+++ b/flightscnr/tests/test_bluetooth_audio.py
@@ -107,6 +107,92 @@ class BluetoothAudioTests(unittest.TestCase):
             self.assertEqual(hit["id"], "42")
             self.assertIsNone(bluetooth_audio.find_sink_for_mac("11:22:33:44:55:66"))
 
+    def test_find_sink_for_mac_uses_mac_field(self):
+        sinks = [
+            {
+                "id": "80",
+                "name": "Creative T100",
+                "description": "Creative T100",
+                "mac": "30:22:00:00:7B:6D",
+            }
+        ]
+        with mock.patch.object(bluetooth_audio, "list_audio_sinks", return_value=sinks):
+            hit = bluetooth_audio.find_sink_for_mac("30:22:00:00:7B:6D")
+            self.assertIsNotNone(hit)
+            self.assertEqual(hit["id"], "80")
+
+    def test_mac_from_bluez_node_name(self):
+        self.assertEqual(
+            bluetooth_audio._mac_from_bluez_node_name(
+                "bluez_output.30_22_00_00_7B_6D.1"
+            ),
+            "30:22:00:00:7B:6D",
+        )
+        self.assertEqual(bluetooth_audio._mac_from_bluez_node_name("alsa_output.usb"), "")
+
+    def test_parse_wpctl_inspect(self):
+        text = (
+            'id 80, type PipeWire:Interface:Node\n'
+            '  * node.name = "bluez_output.30_22_00_00_7B_6D.1"\n'
+            '  * node.description = "Creative T100"\n'
+            '    api.bluez5.address = "30:22:00:00:7B:6D"\n'
+            '  * device.api = "bluez5"\n'
+        )
+        props = bluetooth_audio._parse_wpctl_inspect(text)
+        self.assertEqual(props["node.name"], "bluez_output.30_22_00_00_7B_6D.1")
+        self.assertEqual(props["node.description"], "Creative T100")
+        self.assertEqual(props["api.bluez5.address"], "30:22:00:00:7B:6D")
+        self.assertEqual(props["device.api"], "bluez5")
+
+    def test_list_audio_sinks_wpctl_fallback_enriches_bluez(self):
+        """Issue #42: without pactl, friendly sink names must still match MAC."""
+        status_out = (
+            "Audio\n"
+            " ├─ Sinks:\n"
+            " │  *   57. Built-in Audio Stereo               [vol: 0.40]\n"
+            " │      80. Creative T100                       [vol: 0.40]\n"
+            " │\n"
+            " ├─ Sources:\n"
+        )
+        inspect_80 = (
+            'id 80, type PipeWire:Interface:Node\n'
+            '  * node.name = "bluez_output.30_22_00_00_7B_6D.1"\n'
+            '  * node.description = "Creative T100"\n'
+            '    api.bluez5.address = "30:22:00:00:7B:6D"\n'
+        )
+        inspect_57 = (
+            'id 57, type PipeWire:Interface:Node\n'
+            '  * node.name = "alsa_output.platform-fe00b840.mailbox.stereo-fallback"\n'
+            '  * node.description = "Built-in Audio Stereo"\n'
+        )
+
+        def fake_run(cmd, timeout=4.0):
+            del timeout
+            if cmd[:3] == ["pactl", "list", "short"]:
+                return mock.Mock(returncode=127, stdout="", stderr="not found")
+            if cmd[:2] == ["wpctl", "status"]:
+                return mock.Mock(returncode=0, stdout=status_out, stderr="")
+            if cmd[:2] == ["wpctl", "inspect"]:
+                oid = cmd[2]
+                text = inspect_80 if oid == "80" else inspect_57
+                return mock.Mock(returncode=0, stdout=text, stderr="")
+            return mock.Mock(returncode=1, stdout="", stderr="")
+
+        with mock.patch.object(bluetooth_audio, "_run_as_audio_user", side_effect=fake_run):
+            sinks = bluetooth_audio.list_audio_sinks()
+            hit = bluetooth_audio.find_sink_for_mac("30:22:00:00:7B:6D")
+            usb = bluetooth_audio.find_usb_sink()
+
+        ids = {s["id"] for s in sinks}
+        self.assertEqual(ids, {"57", "80"})
+        bt = next(s for s in sinks if s["id"] == "80")
+        self.assertEqual(bt["name"], "bluez_output.30_22_00_00_7B_6D.1")
+        self.assertEqual(bt["mac"], "30:22:00:00:7B:6D")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["id"], "80")
+        self.assertIsNotNone(usb)
+        self.assertEqual(usb["id"], "57")
+
     def test_status_without_bluetoothctl(self):
         with mock.patch.object(bluetooth_audio, "available", return_value=False):
             with mock.patch.object(bluetooth_audio, "preferred_mac", return_value=""):

--- a/flightscnr/utilities/bluetooth_audio.py
+++ b/flightscnr/utilities/bluetooth_audio.py
@@ -511,8 +511,57 @@ def _mac_to_sink_token(mac: str) -> str:
     return _normalize_mac(mac).replace(":", "_")
 
 
+def _mac_from_bluez_node_name(name: str) -> str:
+    """Extract MAC from PipeWire node names like ``bluez_output.AA_BB_….1``."""
+    text = str(name or "")
+    m = re.search(r"bluez_(?:output|card)\.([0-9A-Fa-f_]{17})", text)
+    if not m:
+        return ""
+    return _normalize_mac(m.group(1).replace("_", ":"))
+
+
+def _parse_wpctl_inspect(text: str) -> dict[str, str]:
+    """Pull useful properties from ``wpctl inspect`` output."""
+    props: dict[str, str] = {}
+    keys = (
+        "node.name",
+        "node.description",
+        "api.bluez5.address",
+        "device.api",
+        "device.description",
+        "device.name",
+        "media.class",
+    )
+    for key in keys:
+        m = re.search(
+            rf'(?:^|\n)\s*\*?\s*{re.escape(key)}\s*=\s*"([^"]*)"',
+            text or "",
+        )
+        if m:
+            props[key] = m.group(1).strip()
+    return props
+
+
+def _wpctl_inspect(object_id: str) -> dict[str, str]:
+    oid = str(object_id or "").strip()
+    if not oid:
+        return {}
+    proc = _run_as_audio_user(["wpctl", "inspect", oid], timeout=4.0)
+    if proc.returncode != 0:
+        return {}
+    return _parse_wpctl_inspect(proc.stdout or "")
+
+
+def _sink_is_bluetooth(sink: dict) -> bool:
+    blob = (
+        f"{sink.get('name', '')} {sink.get('description', '')} "
+        f"{sink.get('mac', '')} {sink.get('device_api', '')}"
+    ).lower()
+    return "bluez" in blob or bool(_normalize_mac(str(sink.get("mac") or "")))
+
+
 def list_audio_sinks() -> list[dict]:
-    """PipeWire/Pulse sinks (id, name, description)."""
+    """PipeWire/Pulse sinks (id, name, description[, mac])."""
     sinks: list[dict] = []
     # pactl short: INDEX\tNAME\tDRIVER\tSAMPLE\tSTATE
     proc = _run_as_audio_user(["pactl", "list", "short", "sinks"], timeout=4.0)
@@ -521,15 +570,20 @@ def list_audio_sinks() -> list[dict]:
             parts = line.split("\t")
             if len(parts) < 2:
                 continue
-            sinks.append(
-                {
-                    "id": parts[0].strip(),
-                    "name": parts[1].strip(),
-                    "description": parts[1].strip(),
-                }
-            )
+            name = parts[1].strip()
+            entry = {
+                "id": parts[0].strip(),
+                "name": name,
+                "description": name,
+            }
+            mac = _mac_from_bluez_node_name(name)
+            if mac:
+                entry["mac"] = mac
+            sinks.append(entry)
         return sinks
-    # Fallback: parse wpctl status Audio/Sinks section lightly.
+    # Fallback when pulseaudio-utils / pactl is missing: parse wpctl status,
+    # then inspect each sink so Bluetooth nodes keep a matchable name/MAC
+    # (friendly labels like "Creative T100" alone are not enough).
     proc = _run_as_audio_user(["wpctl", "status"], timeout=4.0)
     if proc.returncode != 0:
         return sinks
@@ -549,25 +603,47 @@ def list_audio_sinks() -> list[dict]:
         m = re.search(r"(\d+)\.\s+(.+?)(?:\s+\[|$)", line)
         if not m:
             continue
-        sinks.append(
-            {
-                "id": m.group(1),
-                "name": m.group(2).strip(),
-                "description": m.group(2).strip(),
-            }
+        sink_id = m.group(1).strip()
+        friendly = m.group(2).strip()
+        props = _wpctl_inspect(sink_id)
+        node_name = props.get("node.name") or friendly
+        description = (
+            props.get("node.description")
+            or props.get("device.description")
+            or friendly
         )
+        mac = _normalize_mac(props.get("api.bluez5.address") or "")
+        if not mac:
+            mac = _mac_from_bluez_node_name(node_name) or _mac_from_bluez_node_name(
+                props.get("device.name") or ""
+            )
+        entry = {
+            "id": sink_id,
+            "name": node_name,
+            "description": description,
+        }
+        if mac:
+            entry["mac"] = mac
+        if props.get("device.api"):
+            entry["device_api"] = props["device.api"]
+        sinks.append(entry)
     return sinks
 
 
 def find_sink_for_mac(mac: str) -> dict | None:
-    token = _mac_to_sink_token(mac).lower()
-    if not token:
+    mac_n = _normalize_mac(mac)
+    token = _mac_to_sink_token(mac_n).lower()
+    if not mac_n or not token:
         return None
     for sink in list_audio_sinks():
-        blob = f"{sink.get('name', '')} {sink.get('description', '')}".lower()
-        if "bluez" in blob and token in blob.replace(":", "_"):
+        sink_mac = _normalize_mac(str(sink.get("mac") or ""))
+        if sink_mac and sink_mac == mac_n:
             return sink
-        if token in blob.replace(":", "_"):
+        blob = f"{sink.get('name', '')} {sink.get('description', '')}".lower()
+        blob_token = blob.replace(":", "_")
+        if "bluez" in blob and token in blob_token:
+            return sink
+        if token in blob_token:
             return sink
     return None
 
@@ -610,8 +686,7 @@ def find_usb_sink() -> dict | None:
     sinks = list_audio_sinks()
     non_bt = []
     for sink in sinks:
-        blob = f"{sink.get('name', '')} {sink.get('description', '')}".lower()
-        if "bluez" in blob:
+        if _sink_is_bluetooth(sink):
             continue
         non_bt.append(sink)
     if not non_bt:
@@ -702,8 +777,7 @@ def is_output_ready(mac: str | None = None) -> bool:
     if not mac:
         # Any connected bluez sink counts for the speaker gate.
         for sink in list_audio_sinks():
-            name = str(sink.get("name") or "").lower()
-            if "bluez" in name:
+            if _sink_is_bluetooth(sink):
                 return True
         return False
     if not is_connected(mac):

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -99,7 +99,8 @@ install_apt_packages() {
         unzip git curl \
         mpv \
         bluez \
-        libspa-0.2-bluetooth
+        libspa-0.2-bluetooth \
+        pulseaudio-utils
     log_ok "System packages ready"
 }
 


### PR DESCRIPTION
## Summary
- Fixes https://github.com/yashmulgaonkar/FlightScnr_Pi/issues/42
- When `pactl` is unavailable, enrich `wpctl status` sinks with `wpctl inspect` (`node.name`, `api.bluez5.address`) so Bluetooth sinks are detectable
- Add `pulseaudio-utils` to install deps / README