### PR TITLE
Fix Bluetooth sink detection when pactl is unavailable (match by device name)

### DIFF
--- a/flightscnr/utilities/bluetooth_audio.py
+++ b/flightscnr/utilities/bluetooth_audio.py
@@ -563,12 +563,25 @@ def find_sink_for_mac(mac: str) -> dict | None:
     token = _mac_to_sink_token(mac).lower()
     if not token:
         return None
-    for sink in list_audio_sinks():
+    sinks = list_audio_sinks()
+    for sink in sinks:
         blob = f"{sink.get('name', '')} {sink.get('description', '')}".lower()
         if "bluez" in blob and token in blob.replace(":", "_"):
             return sink
         if token in blob.replace(":", "_"):
             return sink
+    # MAC-token matching only works against pactl's technical sink names
+    # (e.g. bluez_output.8C_41_F2_22_DF_33.1). The wpctl status fallback
+    # (used when pactl isn't installed - see list_audio_sinks) only ever
+    # exposes the device's friendly name, never its MAC, so the match above
+    # can never succeed there even when the sink genuinely exists. Fall
+    # back to matching by the device's known name in that case.
+    name = str(_device_info(mac).get("name") or "").strip().lower()
+    if name and name != mac.lower():
+        for sink in sinks:
+            blob = f"{sink.get('name', '')} {sink.get('description', '')}".lower()
+            if name in blob:
+                return sink
     return None
 
 


### PR DESCRIPTION
## Problem

On systems without `pactl` installed, the Bluetooth speaker portal always reports "Connected (no sink)" even when the speaker is genuinely connected and already selected as the PipeWire default sink (confirmed with `wpctl status`). ATC/chime audio fails with "No USB or Bluetooth speaker connected."

Note: `pulseaudio-utils` (which provides `pactl`) isn't reliably installable on current Raspberry Pi OS — it depends on an exact stock Debian `libpulse0` build that conflicts with the `+rpt1` build Raspberry Pi OS ships (which other things, including PipeWire itself, depend on).

## Root cause

`list_audio_sinks()` already has a working fallback: when `pactl` isn't available, it parses `wpctl status` instead, and correctly extracts sinks (verified — both `Built-in Audio Stereo` and the Bluetooth `ZS-RS60BT` sink parse out correctly).

The bug is downstream, in `find_sink_for_mac()`. It matches sinks by searching for the device's MAC address (as `8c_41_f2_22_df_33`) as a substring inside the sink's name/description. That works against `pactl`'s technical sink names, which embed the MAC (e.g. `bluez_output.8C_41_F2_22_DF_33.1`) — but `wpctl status`'s human-readable output never includes the MAC anywhere, only the friendly device name (`ZS-RS60BT`). So on any system using the `wpctl` fallback, MAC-based matching can never succeed, even when the sink is right there.

## Fix

Add a fallback match inside `find_sink_for_mac()`: if MAC-token matching fails, look up the device's name via the already-existing `_device_info()` (which calls `bluetoothctl info`) and match sinks by that name instead. No changes needed at any of the 6 call sites — the function's signature and behavior are unchanged when `pactl` is available (MAC matching still tried first), this only adds a second chance when it isn't.

## Testing

- All 9 existing tests in `test_bluetooth_audio.py` pass unchanged.
- Added a scenario reproducing the exact real-world data (two sinks from a `wpctl`-fallback-shaped list, one named `ZS-RS60BT` with no MAC anywhere) and confirmed `find_sink_for_mac()` now correctly returns it, where it previously returned `None`.