### PR TITLE
Replace native confirm() with custom confirm-row for mobile compatibility

### DIFF
--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -612,6 +612,10 @@
                 <button class="btn" id="btn-check-updates" type="button">Check Updates</button>
                 <button class="btn btn-primary hidden" id="btn-update-now" type="button">Update Now</button>
             </div>
+            <div class="track-row hidden" id="update-confirm-row">
+                <button class="btn btn-primary" id="btn-update-confirm-yes" type="button">Install &amp; Restart</button>
+                <button class="btn" id="btn-update-confirm-no" type="button">Cancel</button>
+            </div>
             <div id="updates-status" class="status"></div>
         </div>
     </details>
@@ -869,11 +873,18 @@ function startUpdatePoll() {
     }, 4000);
 }
 
-async function applyUpdate() {
+function showUpdateConfirm(show) {
+    $("update-confirm-row").classList.toggle("hidden", !show);
+    $("btn-update-now").classList.toggle("hidden", show);
+}
+
+function applyUpdate() {
     clearStatus("updates-status");
-    if (!confirm("Install the latest update and restart FlightScnrPi? Your settings and API keys are preserved.")) {
-        return;
-    }
+    showUpdateConfirm(true);
+}
+
+async function applyUpdateConfirmed() {
+    showUpdateConfirm(false);
     $("btn-update-now").disabled = true;
     try {
         const data = await jsonFetch("/updates/apply", { method: "POST" });
@@ -1861,6 +1872,8 @@ async function requestAppRestart() {
 
 $("btn-check-updates").addEventListener("click", checkUpdates);
 $("btn-update-now").addEventListener("click", applyUpdate);
+$("btn-update-confirm-yes").addEventListener("click", applyUpdateConfirmed);
+$("btn-update-confirm-no").addEventListener("click", () => showUpdateConfirm(false));
 $("btn-restart-app").addEventListener("click", requestAppRestart);
 $("btn-reboot").addEventListener("click", () => requestSystemAction("reboot"));
 $("btn-shutdown").addEventListener("click", () => requestSystemAction("shutdown"));


### PR DESCRIPTION
## Problem

Tapping "Update Now" on a mobile browser does nothing — no prompt, no error, no update. Works fine on desktop.

## Root cause

`applyUpdate()` gates the actual update on a native `window.confirm()` dialog:

```js
if (!confirm("Install the latest update and restart FlightScnrPi? ...")) {
    return;
}
```

`window.confirm()` (and `alert()`) silently become no-ops — returning `undefined` immediately with no dialog ever shown — in a number of common mobile contexts: pages launched from an iOS/Android home-screen icon in standalone/PWA display mode, and various in-app/embedded browser webviews. Since the code treats a falsy return as "user cancelled," the button appears to just do nothing when tapped from those contexts.

The same pattern (`confirm(...)`) is also used for the reboot/shutdown and relaunch buttons (lines ~1373, ~1394) — same underlying bug, out of scope for this PR but worth knowing about.

## Fix

Replace the native `confirm()` with the custom in-page confirmation row the codebase already uses elsewhere (see `#confirm-row` on the flight-tracking "Save anyway / Cancel" flow) — a hidden `<div>` with two buttons, toggled via a CSS class instead of a native browser dialog. This works identically across desktop and every mobile context, since it's just DOM elements rather than a browser API that some environments choose not to implement.

`applyUpdate()` now just reveals the confirm row; the actual POST to `/updates/apply` moved into a new `applyUpdateConfirmed()`, wired to the "Install & Restart" button. "Cancel" just re-hides the row. No backend changes.

## Testing

Verified the confirm row shows/hides correctly and the update POST fires only after clicking "Install & Restart," not on the initial "Update Now" tap. [Note: please confirm on an actual mobile device/PWA context before merging — I don't have a way to reproduce the original silent-failure mobile bug directly to verify the fix resolves it end-to-end, only that the new code no longer depends on `confirm()` at all.]