### PR TITLE
Cut radar CPU and fix root PulseAudio underruns

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -3850,20 +3850,17 @@ class RoundTouchDisplay:
                             frame_debug.stage("loop_body", body)
                     except NameError:
                         pass
-                # Yield less while on radar / countdown ring so frames aren't padded.
+                # Yield less while on radar / countdown ring so frames aren't
+                # padded. 1ms spun ~1000 iterations/s between the ~30fps draws;
+                # 4ms still polls input at 250Hz for a quarter of the spin.
                 _sleep_t = time.perf_counter()
                 ring_animating = self._timeout_remaining_fraction() is not None
-                if self.screen == SCREEN_RADAR or ring_animating:
-                    time.sleep(0.001)
-                else:
-                    time.sleep(0.01)
+                requested = (
+                    0.004 if self.screen == SCREEN_RADAR or ring_animating else 0.01
+                )
+                time.sleep(requested)
                 if FRAME_DEBUG:
                     # Overrun beyond the requested sleep = GIL / OS preemption.
-                    requested = (
-                        0.001
-                        if self.screen == SCREEN_RADAR or ring_animating
-                        else 0.01
-                    )
                     slept = time.perf_counter() - _sleep_t
                     if slept > requested + 0.005:
                         frame_debug.stage("loop_sleep_overrun", slept - requested)

--- a/flightscnr/display/round_touch/theme.py
+++ b/flightscnr/display/round_touch/theme.py
@@ -121,8 +121,11 @@ ALERT_WATCH = ALERT_OTHER
 SCALE_LABEL_BEARING_DEG = 245.5
 RING_COUNT = 3
 SWEEP_PERIOD_MS = 6000
-# Target ~60fps for the sweep; achieved FPS may be lower on Pi full redraws.
-SWEEP_FRAME_MS = 16
+# Target ~30fps. Presenting a frame (rotate + flip) costs ~10ms on the Pi 3
+# regardless of what changed, so this constant sets the CPU floor; compositing
+# the radar itself is <2ms. The sweep is time-based (tick_sweep), so a lower
+# cadence keeps 60°/s and only coarsens the step to ~2°/frame.
+SWEEP_FRAME_MS = 33
 
 
 def in_visible_circle(x: float, y: float, margin: float = 0) -> bool:

--- a/flightscnr/display/round_touch/video.py
+++ b/flightscnr/display/round_touch/video.py
@@ -71,6 +71,14 @@ def init_display(width: int, height: int, fullscreen: bool) -> pygame.Surface:
 
                 if not speaker_connected():
                     os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+                else:
+                    # SDL holds the device open even when nothing is playing, so
+                    # a starved buffer spams snd_pcm_recover forever rather than
+                    # once per sound. 512 frames (~12ms) could not survive the
+                    # render loop; 2048 gives the callback ~46ms of slack.
+                    pygame.mixer.pre_init(
+                        frequency=44100, size=-16, channels=2, buffer=2048
+                    )
             except Exception:
                 pass
             pygame.init()

--- a/flightscnr/setup/flightscnr.service
+++ b/flightscnr/setup/flightscnr.service
@@ -15,6 +15,11 @@ Environment=FLIGHTSCNR_DATA_DIR=/var/lib/flightscnr
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=__XAUTHORITY__
 Environment=XDG_RUNTIME_DIR=__XDG_RUNTIME_DIR__
+# The service is root but the audio server belongs to the desktop user, and
+# libpulse refuses to auto-discover a runtime dir it does not own. Without these
+# SDL and mpv fall back to raw ALSA and underrun continuously.
+Environment=PULSE_SERVER=unix:__XDG_RUNTIME_DIR__/pulse/native
+Environment=PULSE_COOKIE=__PULSE_COOKIE__
 Environment=SDL_VIDEODRIVER=x11
 
 # Wait for the desktop X session before launching pygame (up to 90s after boot).

--- a/install-pi.sh
+++ b/install-pi.sh
@@ -504,6 +504,7 @@ install_systemd_service() {
     local service_src="$SETUP_DIR/flightscnr.service"
     local xauthority="${REPO_OWNER_HOME}/.Xauthority"
     local runtime_dir="/run/user/${REPO_OWNER_UID}"
+    local pulse_cookie="${REPO_OWNER_HOME}/.config/pulse/cookie"
 
     log_step "Installing systemd service (persists across reboot)"
     mkdir -p /etc/NetworkManager/dnsmasq-shared.d
@@ -511,6 +512,7 @@ install_systemd_service() {
         -e "s|__REPO_DIR__|$REPO_ROOT|g" \
         -e "s|__XAUTHORITY__|$xauthority|g" \
         -e "s|__XDG_RUNTIME_DIR__|$runtime_dir|g" \
+        -e "s|__PULSE_COOKIE__|$pulse_cookie|g" \
         "$service_src" > "$SERVICE_DEST"
     chmod 0644 "$SERVICE_DEST"
     systemctl daemon-reload


### PR DESCRIPTION
## Summary
- Lower `SWEEP_FRAME_MS` 16→33 (~30 fps) and idle-sleep 1→4 ms to cut present-bound CPU
- Point the root systemd unit at the desktop user's PipeWire socket via `PULSE_SERVER` / `PULSE_COOKIE`