### PR TITLE
Boot update check + Layers alert toggles

### DIFF
--- a/flightscnr/display/round_touch/alert_prefs.py
+++ b/flightscnr/display/round_touch/alert_prefs.py
@@ -147,6 +147,21 @@ def hide_non_alerted() -> bool:
     return bool(_state.get("alert_hide_non_alerted", False))
 
 
+def toggle_military_enabled() -> bool:
+    update(alert_military=not military_enabled())
+    return military_enabled()
+
+
+def toggle_emergency_enabled() -> bool:
+    update(alert_emergency=not emergency_enabled())
+    return emergency_enabled()
+
+
+def toggle_hide_non_alerted() -> bool:
+    update(alert_hide_non_alerted=not hide_non_alerted())
+    return hide_non_alerted()
+
+
 def watch_callsigns() -> list[str]:
     return list(_watch)
 

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -272,21 +272,27 @@ class RoundTouchDisplay:
             logger.debug("Install re-sync arm failed", exc_info=True)
 
     def _update_check_loop(self) -> None:
-        """Force-check GitHub for updates about three times per day."""
+        """Force-check GitHub once after boot, then about three times per day."""
         from utilities import updater
 
         # Let the boot splash finish before the first network check.
         time.sleep(max(0.5, BOOT_SPLASH_S + 1.0))
+        first = True
         while True:
             try:
-                wait_s = float(updater.seconds_until_next_check())
-                if wait_s > 0:
-                    time.sleep(min(wait_s, updater.CHECK_INTERVAL_S))
-                    continue
+                # Always re-query once after boot so a newer release is not
+                # hidden behind a recent last_check_ts / dismiss for an older tip.
+                if not first:
+                    wait_s = float(updater.seconds_until_next_check())
+                    if wait_s > 0:
+                        time.sleep(min(wait_s, updater.CHECK_INTERVAL_S))
+                        continue
+                first = False
                 updater.check_for_update(force=True)
                 update_bubble.invalidate_cache()
             except Exception:
                 logger.debug("Periodic update check failed", exc_info=True)
+                first = False
                 time.sleep(300.0)
                 continue
             time.sleep(updater.CHECK_INTERVAL_S)
@@ -1321,6 +1327,21 @@ class RoundTouchDisplay:
             return
         elif action == "idle_clock":
             settings.toggle_auto_idle_clock()
+        elif action == "alert_military":
+            from display.round_touch import alert_prefs
+
+            alert_prefs.toggle_military_enabled()
+            radar.invalidate_frame_layer()
+        elif action == "alert_emergency":
+            from display.round_touch import alert_prefs
+
+            alert_prefs.toggle_emergency_enabled()
+            radar.invalidate_frame_layer()
+        elif action == "alert_hide_non_alerted":
+            from display.round_touch import alert_prefs
+
+            alert_prefs.toggle_hide_non_alerted()
+            radar.invalidate_frame_layer()
         elif action == "radar_hud":
             settings.toggle_radar_hud_enabled()
             radar.invalidate_frame_layer()

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -40,7 +40,7 @@ except ImportError:
         name = (hostname or "raspberrypi").split(".")[0].strip() or "raspberrypi"
         return f"http://{name}.local"
 
-from display.round_touch import draw, nav, settings, theme
+from display.round_touch import alert_prefs, draw, nav, settings, theme
 
 PAGE_MAIN = 0
 PAGE_ATC = 1
@@ -103,7 +103,7 @@ OPTIONS_ACTIONS = (
     "map_style",
     "vfr_opacity",
 )
-# Overlay toggles + traffic mode on their own settings page (no scroll required).
+# Overlay toggles + traffic mode + alert filters (may need a light swipe).
 LAYERS_ACTIONS = (
     "traffic",
     "precipitation",
@@ -112,6 +112,9 @@ LAYERS_ACTIONS = (
     "airport_icons",
     "ground_vehicles",
     "idle_clock",
+    "alert_military",
+    "alert_emergency",
+    "alert_hide_non_alerted",
 )
 # LiveATC playback — page 1 (no scroll): stream select + Play/Stop.
 ATC_ACTIONS = (
@@ -1607,6 +1610,9 @@ def _layers_row_labels() -> list[str]:
         "Show Airport Icons",
         "Show Ground Vehicles",
         "Auto Idle Clock",
+        "Alert on military aircraft",
+        "Alert on emergency squawk (7700/7600/7500)",
+        "Hide non-alerted aircraft on radar",
     ]
 
 
@@ -1623,6 +1629,9 @@ _TOGGLE_ROW_STATE = {
     "airport_icons": settings.show_airport_icons,
     "ground_vehicles": settings.show_ground_vehicles,
     "idle_clock": settings.auto_idle_clock_enabled,
+    "alert_military": alert_prefs.military_enabled,
+    "alert_emergency": alert_prefs.emergency_enabled,
+    "alert_hide_non_alerted": alert_prefs.hide_non_alerted,
     "enabled": settings.atc_enabled,
     "quiet": settings.atc_quiet_hours_enabled,
 }


### PR DESCRIPTION
## Summary
- Force-check for firmware updates once after boot, then keep the existing interval
- Add military / emergency squawk / hide-non-alerted toggles under on-device Layers (same `alert_prefs.json` as the portal)