### PR TITLE
Add opt-in altitude-based aircraft coloring (matches ADS-B Exchange/tar1090 gradient)

### DIFF
--- a/flightscnr/display/round_touch/altitude_color.py
+++ b/flightscnr/display/round_touch/altitude_color.py
@@ -1,0 +1,101 @@
+"""Altitude-based aircraft icon coloring, matching the gradient used by
+ADS-B Exchange / tar1090 (see wiedehopf/tar1090's ColorByAlt in defaults.js).
+
+The scheme is HSL-based: altitude maps to hue via a set of breakpoints
+(linearly interpolated between them), and hue in turn maps to a lightness
+value via a second table, so the gradient stays visually balanced rather
+than getting muddy at certain hues. Saturation is constant.
+
+Roughly: low altitude is orange, climbing through yellow and green, then
+cyan/blue, magenta, and finally red at the highest altitudes (51,000ft+).
+"""
+
+from __future__ import annotations
+
+import colorsys
+
+# Altitude (ft) -> hue breakpoints. Linearly interpolated between entries;
+# altitudes outside the range clamp to the nearest endpoint's hue.
+_ALT_HUE_STOPS: list[tuple[float, float]] = [
+    (0, 20),  # orange
+    (2000, 32.5),  # yellow
+    (4000, 43),  # yellow
+    (6000, 54),  # yellow
+    (8000, 72),  # yellow
+    (9000, 85),  # green-yellow
+    (11000, 140),  # light green
+    (40000, 300),  # magenta
+    (51000, 360),  # red
+]
+
+# Hue -> lightness (%) breakpoints, so the gradient stays visually
+# balanced across hues rather than some colors reading darker/muddier
+# than others at the same saturation.
+_HUE_LIGHTNESS_STOPS: list[tuple[float, float]] = [
+    (0, 53),
+    (20, 50),
+    (32, 54),
+    (40, 52),
+    (46, 51),
+    (50, 46),
+    (60, 43),
+    (80, 41),
+    (100, 41),
+    (120, 41),
+    (140, 41),
+    (160, 40),
+    (180, 40),
+    (190, 44),
+    (198, 50),
+    (200, 58),
+    (220, 58),
+    (240, 58),
+    (255, 55),
+    (266, 55),
+    (270, 58),
+    (280, 58),
+    (290, 47),
+    (300, 43),
+    (310, 48),
+    (320, 48),
+    (340, 52),
+    (360, 53),
+]
+
+_AIR_SATURATION = 88
+
+# Fixed colors for aircraft with no usable altitude, matching tar1090's
+# "unknown" HSL entry (light gray).
+UNKNOWN_COLOR = (191, 191, 191)  # HSL(0, 0%, 75%)
+
+
+def _interp(stops: list[tuple[float, float]], x: float) -> float:
+    """Linearly interpolate y for x across a sorted list of (x, y) stops,
+    clamping to the first/last entry outside the covered range."""
+    if x <= stops[0][0]:
+        return stops[0][1]
+    if x >= stops[-1][0]:
+        return stops[-1][1]
+    for (x0, y0), (x1, y1) in zip(stops, stops[1:]):
+        if x0 <= x <= x1:
+            if x1 == x0:
+                return y0
+            frac = (x - x0) / (x1 - x0)
+            return y0 + frac * (y1 - y0)
+    return stops[-1][1]
+
+
+def color_for_altitude(alt_ft) -> tuple[int, int, int]:
+    """Return an RGB tuple for the given altitude in feet, matching
+    ADS-B Exchange / tar1090's altitude color gradient. Returns a neutral
+    gray for missing/invalid altitude."""
+    try:
+        alt = float(alt_ft)
+    except (TypeError, ValueError):
+        return UNKNOWN_COLOR
+
+    hue = _interp(_ALT_HUE_STOPS, alt)
+    lightness = _interp(_HUE_LIGHTNESS_STOPS, hue)
+
+    r, g, b = colorsys.hls_to_rgb(hue / 360.0, lightness / 100.0, _AIR_SATURATION / 100.0)
+    return (round(r * 255), round(g * 255), round(b * 255))

--- a/flightscnr/display/round_touch/screens/radar.py
+++ b/flightscnr/display/round_touch/screens/radar.py
@@ -810,6 +810,10 @@ def _flight_icon_color(flight, *, compact: bool):
             return _overlay_color_for_basemap(theme.AIRCRAFT_UNKNOWN)
     except Exception:
         pass
+    if settings.color_by_altitude():
+        from display.round_touch import altitude_color
+
+        return altitude_color.color_for_altitude(flight.get("altitude"))
     return _overlay_color_for_basemap(theme.AIRCRAFT)
 
 

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -234,6 +234,7 @@ _defaults = {
     "distance_units": "km",
     "unit_preset": "km_kph",
     "show_compass_rose": True,
+    "color_by_altitude": False,
     "show_range_rings": True,
     # Legacy bool kept in sync with traffic_labels for older readers.
     "show_aircraft_tag": True,
@@ -889,6 +890,7 @@ def _settings_snapshot(state: dict) -> tuple:
         tuple(color_presets.normalize_rgb(state.get("runway_darkmap_rgb"))),
         state.get("show_compass_rose"),
         state.get("show_range_rings"),
+        state.get("color_by_altitude"),
         state.get("show_aircraft_tag"),
         state.get("traffic_labels"),
         _normalize_facing(state.get("facing_deg", 0)),
@@ -1501,6 +1503,20 @@ def toggle_compass_rose():
 
 def set_show_compass_rose(enabled: bool):
     _state["show_compass_rose"] = bool(enabled)
+    _save(_state)
+
+
+def color_by_altitude():
+    return bool(_state.get("color_by_altitude", False))
+
+
+def toggle_color_by_altitude():
+    _state["color_by_altitude"] = not color_by_altitude()
+    _save(_state)
+
+
+def set_color_by_altitude(enabled: bool):
+    _state["color_by_altitude"] = bool(enabled)
     _save(_state)
 
 

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -1038,6 +1038,7 @@ def radar_json():
             "runway_darkmap_rgb": list(settings.runway_darkmap_rgb()),
             "show_compass_rose": settings.show_compass_rose(),
             "show_range_rings": settings.show_range_rings(),
+            "color_by_altitude": settings.color_by_altitude(),
             "show_aircraft_tag": settings.show_aircraft_tag(),
             "traffic_labels": settings.traffic_labels(),
             "facing_deg": settings.facing_deg(),
@@ -1130,6 +1131,8 @@ def radar_save():
         settings.set_show_compass_rose(bool(data.get("show_compass_rose")))
     if "show_range_rings" in data:
         settings.set_show_range_rings(bool(data.get("show_range_rings")))
+    if "color_by_altitude" in data:
+        settings.set_color_by_altitude(bool(data.get("color_by_altitude")))
     if "traffic_labels" in data:
         settings.set_traffic_labels(data.get("traffic_labels"))
     elif "show_aircraft_tag" in data:

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -195,6 +195,10 @@
                 <label for="show_range_rings">Show range rings</label>
                 <span class="switch"><input id="show_range_rings" type="checkbox"><span class="track"></span></span>
             </div>
+            <div class="chk">
+                <label for="color_by_altitude">Color aircraft by altitude</label>
+                <span class="switch"><input id="color_by_altitude" type="checkbox"><span class="track"></span></span>
+            </div>
             <label for="traffic_labels">Traffic labels</label>
             <select id="traffic_labels">
                 <option value="aircraft">Aircraft Only</option>
@@ -1007,6 +1011,7 @@ async function loadAll() {
         }
         $("show_compass").checked = !!r.show_compass_rose;
         if ($("show_range_rings")) $("show_range_rings").checked = r.show_range_rings !== false;
+        if ($("color_by_altitude")) $("color_by_altitude").checked = !!r.color_by_altitude;
         if ($("traffic_labels")) $("traffic_labels").value = r.traffic_labels || (r.show_aircraft_tag === false ? "off" : "both");
         $("facing_deg").value = String(Math.round(Number(r.facing_deg) || 0) % 360);
         $("show_sweep").checked = !!r.show_sweep_line;
@@ -1236,6 +1241,7 @@ async function saveRadar() {
                 runway_darkmap_rgb: readRgbInputs("runway"),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
+                color_by_altitude: $("color_by_altitude") ? $("color_by_altitude").checked : false,
                 traffic_labels: $("traffic_labels") ? $("traffic_labels").value : "both",
                 facing_deg: Number($("facing_deg").value),
                 show_sweep_line: $("show_sweep").checked,
@@ -1301,6 +1307,7 @@ async function saveAndReloadSettings() {
                 runway_darkmap_rgb: readRgbInputs("runway"),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
+                color_by_altitude: $("color_by_altitude") ? $("color_by_altitude").checked : false,
                 traffic_labels: $("traffic_labels") ? $("traffic_labels").value : "both",
                 facing_deg: Number($("facing_deg").value),
                 show_sweep_line: $("show_sweep").checked,


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Feature</h2>
<p>Adds an opt-in "Color aircraft by altitude" toggle (Radar settings) that colors aircraft icons using the same gradient ADS-B Exchange / tar1090 uses: orange near the ground, climbing through yellow, green, cyan/blue, magenta, and finally red at the highest altitudes.</p>
<h2>Source of the color scheme</h2>
<p>Pulled directly from <code>wiedehopf/tar1090</code>'s <code>ColorByAlt</code> config (the project ADS-B Exchange's own map is built on): 9 altitude-to-hue breakpoints (linearly interpolated between them, clamped outside the range) combined with a second hue-to-lightness lookup table, so the gradient stays visually balanced rather than getting muddy at certain hues. Saturation is constant. New <code>altitude_color.py</code> reimplements this faithfully in Python (HSL, via <code>colorsys</code>), with the exact breakpoint values transcribed from tar1090's source.</p>
<p>Verified against reference points:</p>

Altitude | Output RGB | Expected
-- | -- | --
0 ft | (240, 90, 15) | orange
11,000 ft | (13, 197, 74) | green
20,000 ft | (13, 179, 210) | cyan/blue
40,000 ft | (206, 13, 206) | magenta
51,000+ ft | (241, 30, 30) | red
missing/invalid | (191, 191, 191) | neutral gray


<h2>Integration</h2>
<ul>
<li>New <code>settings.color_by_altitude()</code> / <code>set_color_by_altitude()</code> / <code>toggle_color_by_altitude()</code>, defaulting to <code>False</code> (opt-in), mirroring the existing <code>show_compass_rose</code> pattern exactly.</li>
<li>Wired through <code>/radar</code> and <code>/radar/json</code> alongside the existing <code>show_compass_rose</code>/<code>show_range_rings</code> fields, and into the portal's Radar settings card with a matching checkbox.</li>
<li>In <code>_flight_icon_color()</code>, altitude coloring applies <strong>only as the final fallback</strong> — tracked aircraft, alerts (military/highlighted), vessels, and unknown-type aircraft all keep their existing distinct colors and take priority, same as today. This only replaces the flat default <code>theme.AIRCRAFT</code> color for ordinary traffic when the toggle is on.</li>
</ul>
<h2>Known limitation</h2>
<p>This gradient was designed for tar1090's typically dark map background. A few of the paler yellow/mid-lightness hues may be harder to read against the light/VFR basemap style specifically: <code>_overlay_color_for_basemap()</code> (which remaps a few fixed theme colors for light-basemap legibility) doesn't apply here since it's a static lookup table, not a generic contrast adjustment, and these are dynamically computed colors. Didn't want to over-engineer a per-hue light-basemap remap without being able to visually verify it; flagging for awareness rather than silently leaving a maybe-non-issue unmentioned.</p>
<h2>Testing</h2>
<p>Verified the color computation against the reference points above. Toggle wiring (settings persistence, portal checkbox, load/save round-trip) follows the same pattern as <code>show_compass_rose</code>/<code>show_range_rings</code>, which are already known-working in this codebase.</p></body></html><!--EndFragment-->
</body>
</html>