### PR TITLE
Fix for issue  #82  to install-pi.sh and no 'pi' user account

### DIFF
--- a/install-pi.sh
+++ b/install-pi.sh
@@ -150,7 +150,7 @@ EOF
 )
 
     for owner in "$REPO_OWNER" pi root; do
-        home_dir="$(getent passwd "$owner" | cut -d: -f6)"
+        home_dir="$(getent passwd "$owner" | cut -d: -f6)" || true
         [ -n "$home_dir" ] || continue
         mkdir -p "${home_dir}/.config/kanshi"
         if printf '%s\n' "$kanshi_body" > "${home_dir}/.config/kanshi/config"; then
@@ -348,7 +348,7 @@ PYROT
                     "/etc/xdg/pcmanfm/${profile}/desktop-items-1.conf"
             fi
             for owner in "$REPO_OWNER" pi root; do
-                home_dir="$(getent passwd "$owner" | cut -d: -f6)"
+                home_dir="$(getent passwd "$owner" | cut -d: -f6)" || true
                 [ -n "$home_dir" ] || continue
                 _set_pcmanfm_wallpaper_conf \
                     "${home_dir}/.config/pcmanfm/${profile}/desktop-items-0.conf"


### PR DESCRIPTION
A fix to issue #82 reported by user 'smileymouse' with the implementation of the suggested fix