### PR TITLE
Add opt-in altitude coloring + on-device Display toggle (#78)

### DIFF
--- a/flightscnr/display/round_touch/altitude_color.py
+++ b/flightscnr/display/round_touch/altitude_color.py
@@ -1,0 +1,101 @@
+"""Altitude-based aircraft icon coloring, matching the gradient used by
+ADS-B Exchange / tar1090 (see wiedehopf/tar1090's ColorByAlt in defaults.js).
+
+The scheme is HSL-based: altitude maps to hue via a set of breakpoints
+(linearly interpolated between them), and hue in turn maps to a lightness
+value via a second table, so the gradient stays visually balanced rather
+than getting muddy at certain hues. Saturation is constant.
+
+Roughly: low altitude is orange, climbing through yellow and green, then
+cyan/blue, magenta, and finally red at the highest altitudes (51,000ft+).
+"""
+
+from __future__ import annotations
+
+import colorsys
+
+# Altitude (ft) -> hue breakpoints. Linearly interpolated between entries;
+# altitudes outside the range clamp to the nearest endpoint's hue.
+_ALT_HUE_STOPS: list[tuple[float, float]] = [
+    (0, 20),  # orange
+    (2000, 32.5),  # yellow
+    (4000, 43),  # yellow
+    (6000, 54),  # yellow
+    (8000, 72),  # yellow
+    (9000, 85),  # green-yellow
+    (11000, 140),  # light green
+    (40000, 300),  # magenta
+    (51000, 360),  # red
+]
+
+# Hue -> lightness (%) breakpoints, so the gradient stays visually
+# balanced across hues rather than some colors reading darker/muddier
+# than others at the same saturation.
+_HUE_LIGHTNESS_STOPS: list[tuple[float, float]] = [
+    (0, 53),
+    (20, 50),
+    (32, 54),
+    (40, 52),
+    (46, 51),
+    (50, 46),
+    (60, 43),
+    (80, 41),
+    (100, 41),
+    (120, 41),
+    (140, 41),
+    (160, 40),
+    (180, 40),
+    (190, 44),
+    (198, 50),
+    (200, 58),
+    (220, 58),
+    (240, 58),
+    (255, 55),
+    (266, 55),
+    (270, 58),
+    (280, 58),
+    (290, 47),
+    (300, 43),
+    (310, 48),
+    (320, 48),
+    (340, 52),
+    (360, 53),
+]
+
+_AIR_SATURATION = 88
+
+# Fixed colors for aircraft with no usable altitude, matching tar1090's
+# "unknown" HSL entry (light gray).
+UNKNOWN_COLOR = (191, 191, 191)  # HSL(0, 0%, 75%)
+
+
+def _interp(stops: list[tuple[float, float]], x: float) -> float:
+    """Linearly interpolate y for x across a sorted list of (x, y) stops,
+    clamping to the first/last entry outside the covered range."""
+    if x <= stops[0][0]:
+        return stops[0][1]
+    if x >= stops[-1][0]:
+        return stops[-1][1]
+    for (x0, y0), (x1, y1) in zip(stops, stops[1:]):
+        if x0 <= x <= x1:
+            if x1 == x0:
+                return y0
+            frac = (x - x0) / (x1 - x0)
+            return y0 + frac * (y1 - y0)
+    return stops[-1][1]
+
+
+def color_for_altitude(alt_ft) -> tuple[int, int, int]:
+    """Return an RGB tuple for the given altitude in feet, matching
+    ADS-B Exchange / tar1090's altitude color gradient. Returns a neutral
+    gray for missing/invalid altitude."""
+    try:
+        alt = float(alt_ft)
+    except (TypeError, ValueError):
+        return UNKNOWN_COLOR
+
+    hue = _interp(_ALT_HUE_STOPS, alt)
+    lightness = _interp(_HUE_LIGHTNESS_STOPS, hue)
+
+    r, g, b = colorsys.hls_to_rgb(hue / 360.0, lightness / 100.0, _AIR_SATURATION / 100.0)
+    return (round(r * 255), round(g * 255), round(b * 255))

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -1347,6 +1347,9 @@ class RoundTouchDisplay:
             settings.cycle_vessel_min_speed()
         elif action == "sweep":
             settings.toggle_sweep_line()
+        elif action == "color_by_altitude":
+            settings.toggle_color_by_altitude()
+            radar.invalidate_frame_layer()
         elif action == "precipitation":
             settings.toggle_show_precipitation()
             rainviewer_overlay.invalidate()

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -76,6 +76,7 @@ DISPLAY_ACTIONS = (
     "compass",
     "range_rings",
     "sweep",
+    "color_by_altitude",
     "units",
     "range",
     "rotate",
@@ -1561,6 +1562,7 @@ def _display_row_labels() -> list[str]:
         "Compass Rose",
         "Radar Range Rings",
         "Radar Sweep Line",
+        "Color by Altitude",
         f"Units: {settings.unit_preset_label()}",
         f"Radar Range: {settings.scale_label()}",
         f"Rotate Screen: {settings.display_rotation()}°",
@@ -1621,6 +1623,7 @@ _TOGGLE_ROW_STATE = {
     "compass": settings.show_compass_rose,
     "range_rings": settings.show_range_rings,
     "sweep": settings.show_sweep_line,
+    "color_by_altitude": settings.color_by_altitude,
     "radar_hud": settings.radar_hud_enabled,
     "precipitation": settings.show_precipitation,
     "wildfires": settings.show_wildfires,
@@ -1756,6 +1759,56 @@ def _draw_settings_rows(
     finally:
         surface.set_clip(clip_prev)
     return max_scroll
+
+
+def _draw_scroll_overflow_cues(
+    surface,
+    top: int,
+    bottom: int,
+    scroll_offset: int,
+    max_scroll: int,
+) -> None:
+    """Modern thin scrollbar on the right when settings rows overflow."""
+    if max_scroll <= 0:
+        return
+
+    track_top = int(top + theme.s(10))
+    track_bottom = int(bottom - theme.s(10))
+    track_h = track_bottom - track_top
+    if track_h < theme.s(24):
+        return
+
+    # Sit on the right of the round viewport, clear of centered labels.
+    track_x = theme.CENTER_X + int(theme.VISIBLE_RADIUS * 0.78)
+    track_w = max(3, theme.s(4))
+    radius = max(2, track_w // 2)
+
+    # Viewport fraction of total content (content = viewport + max_scroll).
+    viewport_h = max(1, bottom - top)
+    content_h = viewport_h + max_scroll
+    thumb_h = max(theme.s(18), int(round(track_h * (viewport_h / content_h))))
+    thumb_h = min(thumb_h, track_h)
+    travel = max(0, track_h - thumb_h)
+    t = 0.0 if max_scroll <= 0 else min(1.0, max(0.0, scroll_offset / float(max_scroll)))
+    thumb_y = track_top + int(round(travel * t))
+
+    track_rect = pygame.Rect(track_x - track_w // 2, track_top, track_w, track_h)
+    thumb_rect = pygame.Rect(track_x - track_w // 2, thumb_y, track_w, thumb_h)
+
+    # Frosted track + solid thumb (reads on light and dark themes).
+    track_surf = pygame.Surface((track_w, track_h), pygame.SRCALPHA)
+    pygame.draw.rect(
+        track_surf,
+        (*theme.HINT[:3], 70),
+        track_surf.get_rect(),
+        border_radius=radius,
+    )
+    surface.blit(track_surf, track_rect.topleft)
+
+    thumb_color = theme.MUTED if hasattr(theme, "MUTED") else theme.LABEL
+    pygame.draw.rect(surface, thumb_color, thumb_rect, border_radius=radius)
+    # Hairline edge for contrast on similar backgrounds.
+    pygame.draw.rect(surface, theme.GRID, thumb_rect, max(1, theme.s(1)), border_radius=radius)
 
 
 def _draw_brightness_slider_row(surface, ry: int, focused: bool) -> None:
@@ -2181,6 +2234,8 @@ def draw_info(
     if page == PAGE_ATC and atc_picker:
         # Full-screen picker; skip footer chrome underneath.
         return draw_atc_picker(surface, atc_picker, scroll_offset=atc_picker_scroll)
+    if max_scroll > 0 and page != PAGE_MAIN:
+        _draw_scroll_overflow_cues(surface, top, bottom, scroll_offset, max_scroll)
     nav.draw_footer_buttons(surface, list(footer_kinds_for_page(page)))
     if page == PAGE_SYSTEM and system_confirm:
         draw_system_confirm_popup(surface, system_confirm)

--- a/flightscnr/display/round_touch/screens/radar.py
+++ b/flightscnr/display/round_touch/screens/radar.py
@@ -812,6 +812,10 @@ def _flight_icon_color(flight, *, compact: bool):
             return _overlay_color_for_basemap(theme.AIRCRAFT_UNKNOWN)
     except Exception:
         pass
+    if settings.color_by_altitude():
+        from display.round_touch import altitude_color
+
+        return altitude_color.color_for_altitude(flight.get("altitude"))
     return _overlay_color_for_basemap(theme.AIRCRAFT)
 
 

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -234,6 +234,7 @@ _defaults = {
     "distance_units": "km",
     "unit_preset": "km_kph",
     "show_compass_rose": True,
+    "color_by_altitude": False,
     "show_range_rings": True,
     # Legacy bool kept in sync with traffic_labels for older readers.
     "show_aircraft_tag": True,
@@ -904,6 +905,7 @@ def _settings_snapshot(state: dict) -> tuple:
         tuple(color_presets.normalize_rgb(state.get("runway_darkmap_rgb"))),
         state.get("show_compass_rose"),
         state.get("show_range_rings"),
+        state.get("color_by_altitude"),
         state.get("show_aircraft_tag"),
         state.get("traffic_labels"),
         _normalize_facing(state.get("facing_deg", 0)),
@@ -1516,6 +1518,20 @@ def toggle_compass_rose():
 
 def set_show_compass_rose(enabled: bool):
     _state["show_compass_rose"] = bool(enabled)
+    _save(_state)
+
+
+def color_by_altitude():
+    return bool(_state.get("color_by_altitude", False))
+
+
+def toggle_color_by_altitude():
+    _state["color_by_altitude"] = not color_by_altitude()
+    _save(_state)
+
+
+def set_color_by_altitude(enabled: bool):
+    _state["color_by_altitude"] = bool(enabled)
     _save(_state)
 
 

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -1038,6 +1038,7 @@ def radar_json():
             "runway_darkmap_rgb": list(settings.runway_darkmap_rgb()),
             "show_compass_rose": settings.show_compass_rose(),
             "show_range_rings": settings.show_range_rings(),
+            "color_by_altitude": settings.color_by_altitude(),
             "show_aircraft_tag": settings.show_aircraft_tag(),
             "traffic_labels": settings.traffic_labels(),
             "facing_deg": settings.facing_deg(),
@@ -1130,6 +1131,8 @@ def radar_save():
         settings.set_show_compass_rose(bool(data.get("show_compass_rose")))
     if "show_range_rings" in data:
         settings.set_show_range_rings(bool(data.get("show_range_rings")))
+    if "color_by_altitude" in data:
+        settings.set_color_by_altitude(bool(data.get("color_by_altitude")))
     if "traffic_labels" in data:
         settings.set_traffic_labels(data.get("traffic_labels"))
     elif "show_aircraft_tag" in data:

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -195,6 +195,10 @@
                 <label for="show_range_rings">Show range rings</label>
                 <span class="switch"><input id="show_range_rings" type="checkbox"><span class="track"></span></span>
             </div>
+            <div class="chk">
+                <label for="color_by_altitude">Color aircraft by altitude</label>
+                <span class="switch"><input id="color_by_altitude" type="checkbox"><span class="track"></span></span>
+            </div>
             <label for="traffic_labels">Traffic labels</label>
             <select id="traffic_labels">
                 <option value="aircraft">Aircraft Only</option>
@@ -1005,6 +1009,7 @@ async function loadAll() {
         }
         $("show_compass").checked = !!r.show_compass_rose;
         if ($("show_range_rings")) $("show_range_rings").checked = r.show_range_rings !== false;
+        if ($("color_by_altitude")) $("color_by_altitude").checked = !!r.color_by_altitude;
         if ($("traffic_labels")) $("traffic_labels").value = r.traffic_labels || (r.show_aircraft_tag === false ? "off" : "both");
         $("facing_deg").value = String(Math.round(Number(r.facing_deg) || 0) % 360);
         $("show_sweep").checked = !!r.show_sweep_line;
@@ -1234,6 +1239,7 @@ async function saveRadar() {
                 runway_darkmap_rgb: readRgbInputs("runway"),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
+                color_by_altitude: $("color_by_altitude") ? $("color_by_altitude").checked : false,
                 traffic_labels: $("traffic_labels") ? $("traffic_labels").value : "both",
                 facing_deg: Number($("facing_deg").value),
                 show_sweep_line: $("show_sweep").checked,
@@ -1299,6 +1305,7 @@ async function saveAndReloadSettings() {
                 runway_darkmap_rgb: readRgbInputs("runway"),
                 show_compass_rose: $("show_compass").checked,
                 show_range_rings: $("show_range_rings") ? $("show_range_rings").checked : true,
+                color_by_altitude: $("color_by_altitude") ? $("color_by_altitude").checked : false,
                 traffic_labels: $("traffic_labels") ? $("traffic_labels").value : "both",
                 facing_deg: Number($("facing_deg").value),
                 show_sweep_line: $("show_sweep").checked,


### PR DESCRIPTION
## Summary
- Brings in community altitude-based aircraft coloring (tar1090/ADS-B Exchange gradient) from #78.
- Adds Settings → Display → Color by Altitude (portal toggle already present).
- Adds a thin right-side scrollbar when settings pages overflow.