### PR TITLE
Force-kill pcmanfm wallpaper calls with timeout -k

### DIFF
--- a/install-pi.sh
+++ b/install-pi.sh
@@ -414,11 +414,11 @@ PYROT
             desk_uid="$(id -u "$desk_user")"
             sudo -u "$desk_user" env DISPLAY="${DISPLAY:-:0}" \
                 XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$desk_uid}" \
-                pcmanfm --set-wallpaper="$wall_splash" --wallpaper-mode=crop \
+                timeout -k 5 10 pcmanfm --set-wallpaper="$wall_splash" --wallpaper-mode=crop \
                 >/dev/null 2>&1 || true
             sudo -u "$desk_user" env DISPLAY="${DISPLAY:-:0}" \
                 XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$desk_uid}" \
-                pcmanfm --reconfigure >/dev/null 2>&1 || true
+                timeout -k 5 10 pcmanfm --reconfigure >/dev/null 2>&1 || true
         }
 
         local profile
@@ -447,11 +447,11 @@ PYROT
         if [ "$(id -u)" -eq 0 ]; then
             env DISPLAY="${DISPLAY:-:0}" \
                 XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/0}" \
-                pcmanfm --set-wallpaper="$wall_splash" --wallpaper-mode=crop \
+                timeout -k 5 10 pcmanfm --set-wallpaper="$wall_splash" --wallpaper-mode=crop \
                 >/dev/null 2>&1 || true
             env DISPLAY="${DISPLAY:-:0}" \
                 XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/0}" \
-                pcmanfm --reconfigure >/dev/null 2>&1 || true
+                timeout -k 5 10 pcmanfm --reconfigure >/dev/null 2>&1 || true
         fi
 
         unset -f _set_pcmanfm_wallpaper_conf _refresh_pcmanfm_wallpaper


### PR DESCRIPTION
## Problem

`install-pi.sh update` can hang indefinitely on a purely cosmetic step (refreshing the desktop wallpaper) when `DISPLAY` points somewhere unreachable — e.g. an SSH client with X11 forwarding enabled by default (MobaXterm does this), which exports a `DISPLAY` value pointing back through the tunnel instead of leaving it unset for the script's own `${DISPLAY:-:0}` fallback to kick in.

Since `pcmanfm --set-wallpaper`/`--reconfigure` have no timeout, they can sit there forever trying to reach a display that isn't there. The `|| true` after each call only helps once the command actually returns, it doesn't prevent the hang itself. In practice this meant a fully successful `git pull` and file sync, immediately followed by the install silently never reaching its final step (restarting the service to actually run the new code), with no error, no timeout, nothing, just a script that looks alive but never finishes.

## Fix

Wrap all four `pcmanfm` invocations (`--set-wallpaper` / `--reconfigure`, both in `_refresh_pcmanfm_wallpaper()` and the duplicated root-autologin case) with `timeout -k 5 10`.

Started with plain `timeout 10`, but real-world testing surfaced a second, worse failure mode: with a forwarded/unreachable `DISPLAY` that *does* connect to something (e.g. MobaXterm's bundled X server on Windows, rather than a fully dead connection), `pcmanfm` can pop a modal "desktop manager is not active" error dialog and sit there holding input focus waiting for a click. Plain `timeout` sends `SIGTERM` after the deadline but does not escalate if the process ignores it. Confirmed with a controlled test against a process that traps `SIGTERM`: `timeout 3` against it still blocked for the full duration of the child process rather than returning after 3s. `timeout -k 5 10` fixes this by forcing a real `SIGKILL` after a grace period if `SIGTERM` alone doesn't work, verified in the same test to return reliably within the expected bound (3s + 2s grace = 5s, exit 137 confirming SIGKILL).

## Testing

- Controlled test isolating the exact failure mode: a script that traps and ignores `SIGTERM`. Plain `timeout 3` against it did not return until the child's full 60s runtime elapsed. `timeout -k 2 3` against the same script force-killed it and returned in 5s (exit 137).
- Reproduced the original hang on a Pi 4B via an SSH client with X11 forwarding enabled, in two forms: a silent network-level hang, and (with a plain-`timeout`-only version) a focus-stealing "desktop manager is not active" modal dialog that plain `timeout 10` failed to clear even after 10s. Confirmed on-device that `timeout -k 5 10` force-closes the dialog and the install continues unattended within ~15s, with no manual interaction needed.