### PR TITLE
Add squawk code watch list

### DIFF
--- a/flightscnr/display/round_touch/alert_prefs.py
+++ b/flightscnr/display/round_touch/alert_prefs.py
@@ -55,6 +55,60 @@ def _parse_watch(blob: str) -> list[str]:
             out.append(token)
     return out
 
+def _parse_squawk(squawk_input: str) -> list[str]:
+    """
+    Parse a string containing individual squawk codes and/or ranges.
+    Returns a list of all valid squawk codes.
+    
+    Examples:
+        "7500,7600,7700" -> "7500", "7600", "7700"
+        "4301-4307,7500" -> "4301", "4302", ..., "4307", "7500"
+    """
+
+    squawk_list: list[str] = []
+    
+    # Split by comma and process each part
+    parts = squawk_input.split(',')
+    
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+            
+        # Check if it's a range (contains '-')
+        if '-' in part:
+            try:
+                start, end = part.split('-')
+                start = int(start.strip())
+                end = int(end.strip())
+                
+                # Validate range
+                if start > end:
+                    logger.warning("Warning: Invalid range %s, start > end, therefore values swapped", part)
+                    start, end = end, start
+
+                start = max(start, 0)
+                end = min(end, 7777)                
+
+                # Add all codes in the range (as zero-padded 4-digit strings)
+                for code in range(start, end + 1):
+                    squawk_list.append(f"{code:04d}")
+            except ValueError:
+                logger.warning("Warning: Invalid range format %s", part)
+                continue
+        else:
+            # Individual code
+            try:
+                code = int(part)
+                if 0 <= code <= 7777:
+                    squawk_list.append(f"{code:04d}")
+                else:
+                    logger.warning("Warning: Squawk code %s outside valid range (0000-7777)", part)
+            except ValueError:
+                logger.warning("Warning: Invalid squawk code %s", part)
+        
+    return squawk_list
+
 
 _defaults = {
     "alert_military": True,
@@ -62,6 +116,7 @@ _defaults = {
     "alert_hide_non_alerted": False,
     "alert_watch": "",
     "alert_watch_types": "",
+    "alert_squawk": "",
 }
 
 
@@ -113,6 +168,8 @@ def _load() -> dict:
 _state = _load()
 _watch = _parse_watch(_state.get("alert_watch", ""))
 _watch_types = _parse_watch_types(_state.get("alert_watch_types", ""))
+_squawk_non_parsed = _state.get("alert_squawk", "")
+_squawk = _parse_squawk(_state.get("alert_squawk", ""))
 try:
     _last_mtime: float | None = (
         os.path.getmtime(ALERT_PATH) if os.path.exists(ALERT_PATH) else None
@@ -122,7 +179,7 @@ except OSError:
 
 
 def reload():
-    global _state, _watch, _watch_types, _last_mtime
+    global _state, _watch, _watch_types, _squawk, _squawk_non_parsed, _last_mtime
     try:
         mtime = os.path.getmtime(ALERT_PATH) if os.path.exists(ALERT_PATH) else None
     except OSError:
@@ -133,6 +190,8 @@ def reload():
     _state = _load()
     _watch = _parse_watch(_state.get("alert_watch", ""))
     _watch_types = _parse_watch_types(_state.get("alert_watch_types", ""))
+    _squawk_non_parsed = _state.get("alert_squawk", "")
+    _squawk = _parse_squawk(_state.get("alert_squawk", ""))
 
 
 def military_enabled() -> bool:
@@ -178,8 +237,15 @@ def watch_types_blob() -> str:
     return _state.get("alert_watch_types", "") or ""
 
 
+def squawk_callsigns() -> list[str]:
+    return list(_squawk)
+
+def squawk_blob() -> str:
+    return _state.get("alert_squawk", "") or ""
+
+
 def alerts_active() -> bool:
-    return military_enabled() or emergency_enabled() or bool(_watch) or bool(_watch_types)
+    return military_enabled() or emergency_enabled() or bool(_watch) or bool(_watch_types) or bool(_squawk)
 
 
 def update(
@@ -189,8 +255,9 @@ def update(
     alert_hide_non_alerted: bool | None = None,
     alert_watch: str | None = None,
     alert_watch_types: str | None = None,
+    alert_squawk: str | None = None,
 ) -> None:
-    global _watch, _watch_types, _last_mtime
+    global _watch, _watch_types, _squawk, _squawk_non_parsed, _last_mtime
     if alert_military is not None:
         _state["alert_military"] = bool(alert_military)
     if alert_emergency is not None:
@@ -203,6 +270,10 @@ def update(
     if alert_watch_types is not None:
         _watch_types = _parse_watch_types(alert_watch_types)
         _state["alert_watch_types"] = ",".join(_watch_types)
+    if alert_squawk is not None:
+        _squawk_non_parsed = alert_squawk
+        _squawk = _parse_squawk(alert_squawk)
+        _state["alert_squawk"] = _squawk_non_parsed
     _save(_state)
     try:
         _last_mtime = os.path.getmtime(ALERT_PATH)

--- a/flightscnr/utilities/aircraft_alert.py
+++ b/flightscnr/utilities/aircraft_alert.py
@@ -29,7 +29,7 @@ _RIM_REFLASH_S = 4.0
 _attention_until = 0.0
 _ATTENTION_HOLD_S = 20.0
 _rim_flash_military = False
-_rim_flash_watch = False
+_rim_flash_watch = False        
 _rim_flash_emergency = False
 
 # ICAO types listed under military-* icon categories (e.g. Q9 → military-drone).
@@ -565,6 +565,14 @@ def on_watchlist_type(flight: dict) -> bool:
     return False
 
 
+def is_a_squawk(flight: dict) -> bool:
+    # Get raw squawk list string from preferences
+    squawk_input = alert_prefs.squawk_callsigns()  # This should return the raw string
+    #squawk_list = alert_prefs.parse_squawk_list(squawk_input)
+    squawk = normalize_squawk(flight.get("squawk"))
+    return squawk in squawk_input
+
+
 def should_alert(flight: dict) -> bool:
     if flight.get("kind") == "vessel":
         return False
@@ -574,6 +582,8 @@ def should_alert(flight: dict) -> bool:
         return True
     if alert_prefs.military_enabled() and is_military(flight):
         return True
+    if is_a_squawk(flight):
+        return True 
     return False
 
 
@@ -607,6 +617,8 @@ def alert_color(flight: dict):
         return theme.ALERT_EMERGENCY
     if on_watchlist(flight):
         return theme.ALERT_WATCH
+    if is_a_squawk(flight):
+        return theme.ALERT_OTHER
     if alert_prefs.military_enabled() and is_military(flight):
         return theme.ALERT_MILITARY
     return theme.AIRCRAFT
@@ -703,11 +715,12 @@ def check_new_aircraft(flights: list[dict]) -> bool:
         if alert_prefs.emergency_enabled() and is_emergency_squawk(flight):
             saw_emergency = True
         logger.info(
-            "ALERT %s mil=%s emrg=%s watch=%s squawk=%s",
+            "ALERT %s mil=%s emrg=%s watch=%s squawk=%s squawk=%s",
             cs,
             is_military(flight),
             is_emergency_squawk(flight),
             on_watchlist(flight),
+            is_a_squawk(flight),
             flight.get("squawk"),
         )
     if fired:

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -725,6 +725,7 @@ def alerts_json():
             "alert_hide_non_alerted": alert_prefs.hide_non_alerted(),
             "alert_watch": alert_prefs.watch_blob(),
             "alert_watch_types": alert_prefs.watch_types_blob(),
+            "alert_squawk": alert_prefs.squawk_blob(),
         }
     )
 
@@ -740,6 +741,7 @@ def alerts_save():
         alert_hide_non_alerted=bool(data.get("alert_hide_non_alerted", False)),
         alert_watch=str(data.get("alert_watch", "") or ""),
         alert_watch_types=str(data.get("alert_watch_types", "") or ""),
+        alert_squawk=str(data.get("alert_squawk", "") or ""),
     )
     return jsonify({"ok": True})
 

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -341,6 +341,9 @@
             <label for="alert-watch-types">Watch list (aircraft types)</label>
             <input id="alert-watch-types" type="text" autocomplete="off" placeholder="B738, A337, A330-743">
             <p class="hint">Alert on every aircraft of a given type on local radar. Use ICAO type codes (B738, A337) or designations (A330-743), comma-separated. Clear and Save to remove.</p>
+            <label for="alert-squawk">Squawk list (squawk codes - non emergency)</label>
+            <input id="alert-squawk" type="text" autocomplete="off" placeholder="0023,0450-0457,0460-0467,1200,2000,7000">
+            <p class="hint">Highlight many aircraft on the <strong>local radar</strong> when they enter range. Enter individual Squawk codes or a range of codes, comma-separated. Clear and Save to remove.</p>
             <button class="btn btn-primary" id="btn-alerts" style="margin-top:.7rem" type="button">Save alerts</button>
             <div id="alert-status" class="status"></div>
         </div>
@@ -1117,6 +1120,7 @@ async function loadAll() {
         $("alert-hide").checked = !!a.alert_hide_non_alerted;
         $("alert-watch").value = a.alert_watch || "";
         if ($("alert-watch-types")) $("alert-watch-types").value = a.alert_watch_types || "";
+        $("alert-squawk").value = a.alert_squawk || "";
     } catch (_) {}
 
     try {
@@ -1454,6 +1458,7 @@ async function saveAlerts() {
                 alert_hide_non_alerted: $("alert-hide").checked,
                 alert_watch: $("alert-watch").value.trim().toUpperCase(),
                 alert_watch_types: ($("alert-watch-types") ? $("alert-watch-types").value : "").trim().toUpperCase(),
+                alert_squawk: $("alert-squawk").value.trim().toUpperCase(),
             }),
         });
         showStatus("alert-status", "Alert settings saved.");


### PR DESCRIPTION
A new field in the alerts section of the web portal that allows you to enter a single squawk code, or a range, or a mixture of multiple,  singles or ranges.

The code creates a list of the codes. If a range is entered i.e 7000-7005 it will parse it to all numbers in that range.

Examples:
        "7500,7600,7700" -> "7500", "7600", "7700"
        "4301-4307,7500" -> "4301", "4302", ..., "4307", "7500"

If it a plane is one of the codes in the list it will appear on the display as theme.ALERT_OTHER

files altered:
\display\round_touch\alert_prefs.py
\utilities\aircraft_alert.py
\web\app.py
\web\templates\index.html