### PR TITLE
Fix aircraft blips for non-north radar facing

### DIFF
--- a/flightscnr/display/round_touch/aircraft_type_icons.py
+++ b/flightscnr/display/round_touch/aircraft_type_icons.py
@@ -409,6 +409,8 @@ def draw_icon(
             )
         return False
 
+    # heading_deg is screen heading (0 = up). Negative pygame angle is CW,
+    # so a nose-up PNG turns to point along track.
     rotated = pygame.transform.rotate(icon, -float(heading_deg))
     rect = rotated.get_rect(center=center)
     surface.blit(rotated, rect)

--- a/flightscnr/display/round_touch/geo.py
+++ b/flightscnr/display/round_touch/geo.py
@@ -55,7 +55,13 @@ def rotate_offset(dx_km: float, dy_km: float, facing_deg: float = 0.0):
 
 
 def screen_heading(heading_deg: float, facing_deg: float | None = None) -> float:
-    """Map geographic heading to screen heading (nose angle for icons)."""
+    """Map geographic heading to screen heading (nose angle for icons).
+
+    0° = screen-up, 90° = screen-right — the same convention as the vector
+    silhouette and ``pygame.transform.rotate(icon, -heading)``. Subtracting
+    ``facing_deg`` keeps the nose along track when the compass is not north-up
+    (east-up: geographic east → screen-up).
+    """
     if facing_deg is None:
         facing_deg = settings.effective_facing_deg()
     return float(heading_deg or 0) - float(facing_deg or 0)

--- a/flightscnr/display/round_touch/map_bg.py
+++ b/flightscnr/display/round_touch/map_bg.py
@@ -975,8 +975,10 @@ def lat_lon_to_basemap_screen(
     vx = (mx - home_px) * render_scale
     vy = (my - home_py) * render_scale
     if abs(facing) >= 0.05:
-        # Same CCW rotation pygame applies to the basemap surface.
-        vx, vy = vx * cos_a - vy * sin_a, vx * sin_a + vy * cos_a
+        # pygame.transform.rotate(surf, facing) is visual CCW in y-down
+        # pixel space: east (+x) goes to screen-up (−y). Math CCW would send
+        # east down and leave icons 180° off the map (issue #92).
+        vx, vy = vx * cos_a + vy * sin_a, -vx * sin_a + vy * cos_a
     return (
         theme.CENTER_X + int(round(vx)),
         theme.CENTER_Y + int(round(vy)),
@@ -1017,8 +1019,8 @@ def basemap_screen_to_lat_lon(
         rad = math.radians(facing)
         cos_a = math.cos(rad)
         sin_a = math.sin(rad)
-        # Inverse of the CCW facing rotation applied in lat_lon_to_basemap_screen.
-        vx, vy = vx * cos_a + vy * sin_a, -vx * sin_a + vy * cos_a
+        # Inverse of the pygame-matching facing rotation above.
+        vx, vy = vx * cos_a - vy * sin_a, vx * sin_a + vy * cos_a
     if render_scale:
         vx /= render_scale
         vy /= render_scale

--- a/flightscnr/tests/test_basemap_projection.py
+++ b/flightscnr/tests/test_basemap_projection.py
@@ -73,6 +73,54 @@ class TestBasemapProjection(unittest.TestCase):
         self.assertAlmostEqual(lat, target[0], places=4)
         self.assertAlmostEqual(lon, target[1], places=4)
 
+    def test_east_of_home_is_screen_up_when_east_up(self):
+        """Basemap facing must match pygame.rotate (issue #92).
+
+        East-up: a point east of home sits above center (same as ENU / compass),
+        not below it. The old math-CCW matrix put east down, so noses pointed
+        opposite the track on the tile map.
+        """
+        from display.round_touch import geo, map_bg, theme
+
+        home = [37.62, -122.37]
+        cos_lat = math.cos(math.radians(home[0]))
+        lon = home[1] + 0.5 / (111.320 * cos_lat)
+        lat = home[0]
+
+        self.settings.set_facing_deg(90)
+        with patch("display.round_touch.geo.LOCATION_HOME", home), patch(
+            "config.LOCATION_HOME", home
+        ), patch.object(map_bg, "_enabled", return_value=True):
+            x, y = geo.lat_lon_to_screen(lat, lon)
+            merc = map_bg.lat_lon_to_basemap_screen(
+                lat, lon, center_lat=home[0], center_lon=home[1]
+            )
+
+        self.assertEqual((x, y), merc)
+        self.assertAlmostEqual(x, theme.CENTER_X, delta=2)
+        self.assertLess(y, theme.CENTER_Y)
+
+    def test_east_up_basemap_roundtrip(self):
+        from display.round_touch import geo, map_bg
+
+        home = [37.62, -122.37]
+        target = (37.625, -122.365)
+        self.settings.set_facing_deg(90)
+        with patch("display.round_touch.geo.LOCATION_HOME", home), patch(
+            "config.LOCATION_HOME", home
+        ), patch.object(map_bg, "_enabled", return_value=True):
+            x, y = geo.lat_lon_to_screen(*target)
+            lat, lon = geo.screen_to_lat_lon(x, y)
+
+        self.assertAlmostEqual(lat, target[0], places=3)
+        self.assertAlmostEqual(lon, target[1], places=3)
+
+    def test_screen_heading_eastbound_is_up_when_east_up(self):
+        from display.round_touch.geo import screen_heading
+
+        self.assertAlmostEqual(screen_heading(90, 90), 0)
+        self.assertAlmostEqual(screen_heading(0, 90), -90)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #92. Aircraft markers were 180° off the basemap when compass facing was not north.