### PR TITLE
Fix live clear of route source order

### DIFF
--- a/flightscnr/secrets_store.py
+++ b/flightscnr/secrets_store.py
@@ -55,7 +55,7 @@ CONFIG_H_SETTINGS = MANAGED_KEYS + (
     "VESSEL_PARKED_SOG_KT",
     "DUMP1090_ENABLED",
     "DUMP1090_URL",
-    "ROUTE_SOURCE_ORDER"
+    "ROUTE_SOURCE_ORDER",
 )
 
 TOGGLE_KEYS = (
@@ -241,6 +241,7 @@ def dump1090_settings() -> dict:
         "DUMP1090_URL": url or "http://127.0.0.1:8080/data/aircraft.json",
     }
 
+
 def route_source_order_setting() -> dict:
     """Current route-source-order portal/settings value.
 
@@ -277,6 +278,7 @@ def apply_dump1090_to_runtime(enabled: bool, url: str) -> None:
         cfg.DUMP1090_URL = url
     except Exception:
         pass
+
 
 def mask_secret(value: str) -> str:
     value = (value or "").strip()
@@ -404,11 +406,16 @@ def save_secrets_from_portal(payload: dict) -> dict[str, str]:
         raw = str(payload.get("route_source_order") or "").strip()
         if raw:
             updated["ROUTE_SOURCE_ORDER"] = raw
+            os.environ["ROUTE_SOURCE_ORDER"] = raw
         else:
             # Clearing to default: remove the key entirely rather than
             # writing "" — keeps secrets.json free of no-op entries and
             # matches how an unset .env var behaves.
+            # Also drop process env: bootstrap_secrets() may have stamped a
+            # previous portal value into os.environ, and route_source_order_setting()
+            # falls back to env when the file key is gone.
             updated.pop("ROUTE_SOURCE_ORDER", None)
+            os.environ.pop("ROUTE_SOURCE_ORDER", None)
 
     os.makedirs(DATA_DIR, exist_ok=True)
     tmp = SECRETS_JSON_PATH + ".tmp"

--- a/flightscnr/tests/test_route_source_order.py
+++ b/flightscnr/tests/test_route_source_order.py
@@ -106,10 +106,58 @@ def test_custom_order_fills_gaps_and_stops_once_complete():
         assert result["route_source"] == "opensky+airlabs"
 
 
+def test_clearing_route_source_order_resets_live_effective_order():
+    """Blank portal save must drop process env, not only secrets.json.
+
+    bootstrap_secrets() stamps a previous portal value into os.environ.
+    After the file key is popped, route_source_order_setting() falls back to
+    that env string, so effective order stayed custom until restart.
+    """
+    import json
+    import tempfile
+
+    import secrets_store as ss
+
+    tmp = tempfile.TemporaryDirectory()
+    secrets_path = os.path.join(tmp.name, "secrets.json")
+    prev = os.environ.pop("ROUTE_SOURCE_ORDER", None)
+    try:
+        with patch.object(ss, "DATA_DIR", tmp.name), patch.object(
+            ss, "SECRETS_JSON_PATH", secrets_path
+        ):
+            ss.save_secrets_from_portal({"route_source_order": "opensky"})
+            assert os.environ.get("ROUTE_SOURCE_ORDER") == "opensky"
+            with open(secrets_path, encoding="utf-8") as fh:
+                saved = json.load(fh)
+            assert saved.get("ROUTE_SOURCE_ORDER") == "opensky"
+            assert (
+                ss.route_source_order_setting()["ROUTE_SOURCE_ORDER_EFFECTIVE"]
+                == "opensky"
+            )
+
+            ss.save_secrets_from_portal({"route_source_order": ""})
+            assert "ROUTE_SOURCE_ORDER" not in os.environ
+            with open(secrets_path, encoding="utf-8") as fh:
+                saved = json.load(fh)
+            assert "ROUTE_SOURCE_ORDER" not in saved
+            setting = ss.route_source_order_setting()
+            assert setting["ROUTE_SOURCE_ORDER"] == ""
+            assert setting["ROUTE_SOURCE_ORDER_EFFECTIVE"] == (
+                "airlabs,flightaware,opensky"
+            )
+    finally:
+        tmp.cleanup()
+        if prev is None:
+            os.environ.pop("ROUTE_SOURCE_ORDER", None)
+        else:
+            os.environ["ROUTE_SOURCE_ORDER"] = prev
+
+
 if __name__ == "__main__":
     test_parse_route_source_order_default_when_unset()
     test_parse_route_source_order_respects_custom_order()
     test_parse_route_source_order_drops_unknown_and_duplicate_entries()
     test_disabled_sources_are_never_called()
     test_custom_order_fills_gaps_and_stops_once_complete()
+    test_clearing_route_source_order_resets_live_effective_order()
     print("All route source order tests passed.")

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -1169,7 +1169,7 @@ async function loadAll() {
         if ($("route_source_order")) {
             $("route_source_order").value = rso.ROUTE_SOURCE_ORDER || "";
         }
-	const faUsage = keys.flightaware_usage;
+        const faUsage = keys.flightaware_usage;
         if ($("flightaware-usage") && faUsage) {
             $("flightaware-usage").textContent =
                 `FlightAware this month: $${Number(faUsage.spend_usd || 0).toFixed(2)} / $${Number(faUsage.monthly_limit_usd || 4.5).toFixed(2)} (${faUsage.calls || 0} calls)`;
@@ -1346,13 +1346,14 @@ async function saveRouteSourceOrder() {
                 route_source_order: raw,
             }),
         });
-	//Show the *effective (parse(filtered) order, not just what was typed
-	//unknown or misspelled entries are silently dropped, so this is the only way to notice a typo actually did something
+        // Show the *effective* (parsed/filtered) order, not just what was typed.
+        // Unknown or misspelled entries are silently dropped, so this is the
+        // only way to notice a typo actually did something.
         const effective =
             (resp.keys && resp.keys.route_source_order &&
                 resp.keys.route_source_order.ROUTE_SOURCE_ORDER_EFFECTIVE) ||
             "airlabs,flightaware,opensky";
-	showStatus("route-source-order-status", `Saved — effective order: ${effective}`);
+        showStatus("route-source-order-status", `Saved — effective order: ${effective}`);
         await loadAll();
     } catch (e) {
         showStatus("route-source-order-status", e.message, true);


### PR DESCRIPTION
Follow-up to #69. Blank Save now pops ROUTE_SOURCE_ORDER from secrets.json and os.environ so the default order applies without a restart. Also replace leftover tab indents in the portal.