### PR TITLE
Don't wipe weather cache on manual refresh - loses fallback data on a 429

### DIFF
--- a/flightscnr/display/round_touch/weather_data.py
+++ b/flightscnr/display/round_touch/weather_data.py
@@ -148,14 +148,20 @@ def refresh(force: bool = False) -> dict | None:
         from utilities.temperature import (
             allow_immediate_fetch,
             consume_manual_refresh_request,
-            invalidate_caches,
         )
 
         if consume_manual_refresh_request():
             force = True
             allow_immediate_fetch()
-            invalidate_caches()
-            invalidate_cache()
+            # Do NOT invalidate_caches()/invalidate_cache() here: force=True
+            # already makes grab_temperature_and_humidity()/grab_forecast()
+            # bypass their TTL and attempt a real fetch. Wiping the cache
+            # first only destroys the fallback data those functions (and
+            # this one, a few lines down) rely on if the forced fetch hits
+            # another 429 - which is common right after a manual refresh
+            # while still rate-limited, since allow_immediate_fetch() only
+            # clears our own local backoff timer, not Tomorrow.io's actual
+            # server-side quota.
             logger.info("Manual weather refresh requested")
     except Exception:
         pass


### PR DESCRIPTION
## Problem

When Tomorrow.io rate-limits the app (429), weather correctly keeps showing the last known-good reading. Every fetch path in `temperature.py` already falls back to its cache on a 429, and `weather_data.refresh()` has its own last-resort fallback too ("Keep the last good reading when the provider is rate-limiting").

But triggering a **manual** refresh (portal "Fetch weather now," or the on-device equivalent) while still rate-limited can wipe that safety net and leave the clock/forecast screens genuinely blank instead.

## Root cause

At the top of `weather_data.refresh()`, when a manual refresh is requested:

```python
if consume_manual_refresh_request():
    force = True
    allow_immediate_fetch()
    invalidate_caches()   # wipes temperature.py's realtime/forecast cache
    invalidate_cache()    # wipes this module's own merged payload cache
```

`allow_immediate_fetch()` only clears our own local backoff timer. Its own docstring says as much: *"Still subject to Tomorrow.io's real quotas, do not spam this."* If the real server-side limit hasn't actually reset, the forced fetch can hit another 429 immediately. At that point:
- `grab_temperature_and_humidity()`/`grab_forecast()` try to fall back to their cache, but it was just wiped by `invalidate_caches()`.
- `weather_data.refresh()`'s own fallback (`prev = _CACHE.get("payload")`) is also empty, since `invalidate_cache()` wiped it moments earlier.

Result: a payload with `"ready": False` and every field blank/`None`, even though a perfectly good recent reading existed seconds before the manual refresh was requested.

## Fix

Remove the `invalidate_caches()`/`invalidate_cache()` calls from this path. They're not actually needed: `force=True` (already set right above) is sufficient on its own to make `grab_temperature_and_humidity()`/`grab_forecast()` bypass their TTL and attempt a genuine fresh fetch. Wiping the cache first adds no benefit and only removes the fallback data needed if that fresh attempt fails.

Other `invalidate_cache()` call sites (location change, unit change, timezone change) are untouched. Those are correctly clearing the cache, since stale data for the *wrong* location/units would be actively misleading, unlike the rate-limit case where stale-but-correct data is strictly better than nothing.

## Testing

Traced all three fetch paths (`temperature.py`'s realtime call, the primary `/timelines` path, and the free-tier `weather/forecast` fallback path) to confirm each already falls back to cache correctly on a 429. The bug was specifically in this one cache-invalidation step short-circuiting that existing safety net, not a missing fallback elsewhere.

Did not reproduce this live against a real rate-limited state on hardware, since doing so deliberately would mean intentionally exhausting a real Tomorrow.io quota just to trigger it. The logic itself is straightforward to verify by reading the diff: `force=True` already guarantees a fresh fetch attempt on its own, so removing the cache-wipe can only preserve more fallback data than before, never less. Happy to do a live reproduction (e.g. simulating a 429 without touching a real quota) if that would help review confidence.