### PR TITLE
Show IATA flight numbers on radar tags

### DIFF
--- a/flightscnr/assets/aircraft/icons/aircraft-icons.json
+++ b/flightscnr/assets/aircraft/icons/aircraft-icons.json
@@ -130,12 +130,12 @@
 
     "business-jet": ["C500", "C501", "C510", "C525", "C550", "C560", "C56X", "C680", "C68A", "C700", "C750",
                     "C25A", "C25B", "C25C", "C25M", "J328","GA7C","GA8C",
-                    "CL30", "CL35", "CL60", "GL5T", "GL7T", "GLEX",
+                    "CL30", "CL35", "CL60", "GL5T", "GL7T", "GLEX","C650",
                     "G150", "G200", "G280", "GLF2", "GLF3", "GLF4", "GLF5", "GLF6", "G500", "G550", "G650",
                     "F900", "F2TH", "FA50", "FA7X", "FA8X", "ASTR", "GALX",
                     "E35L", "E50P", "E55P", "E545", "E550","GA5C",
                     "LJ23", "LJ24", "LJ25", "LJ31", "LJ35", "LJ40", "LJ45", "LJ55", "LJ60", "LJ70", "LJ75",
-                    "H25A", "H25B", "H25C", "HA4T", "HDJT",
+                    "H25A", "H25B", "H25C", "HA4T", "HDJT","c55b",
                     "BE40", "BE4W", "PRM1", "PC24", "EA50", "EVOT","GA6C","SF50"],
 
     "turboprop": ["AT43", "AT45", "AT72", "AT73", "AT75", "AT76",
@@ -151,7 +151,7 @@
                          "SR20", "SR22", "DA20", "DA40", "M20P", "M20T", "BE33", "BE35", "BE36","TEX2","SLG4","YK52",
                          "YK50","P32R","C120","SLG2","D11","E200","CP10","BDOG","EFOX","GX","R300",
                          "C42","SKRA","SKAR","BE23","P32T","AP22","P28S","P208","HR20","DR40",
-                         "BREZ","BR23","C77R","BL8",
+                         "BREZ","BR23","C77R","BL8","BR23","M700",
                          "RV6", "RV7", "RV8", "RV9", "RV10", "RV12", "RV14","DA50","P28A","PC12","C180","COL4","P28B",
                          "ERCO","AT5T","TBM9","PA38","P28R","S22T","K100","CH7A","TB21","CC11"],
 

--- a/flightscnr/tests/test_airline_branding.py
+++ b/flightscnr/tests/test_airline_branding.py
@@ -12,7 +12,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from utilities.airline_branding import display_flight_id, resolve_logo_icao
+from utilities.airline_branding import display_flight_id, prefer_marketing_flight_id, resolve_logo_icao
 
 
 def test_skywest_united_flight_number():
@@ -52,4 +52,44 @@ def test_display_flight_id_skywest_united():
 
 
 def test_display_flight_id_direct_carrier():
-    assert display_flight_id(flight_number="UAL1684", callsign="UAL1684") == "UAL1684"
+    assert display_flight_id(flight_number="UAL1684", callsign="UAL1684") == "UA1684"
+
+
+def test_display_flight_id_icao_only_callsign():
+    assert display_flight_id(flight_number="", callsign="UAL34") == "UA34"
+
+
+def test_display_flight_id_regional_without_marketing():
+    assert display_flight_id(flight_number="", callsign="SKW5510") == "SKW5510"
+
+
+def test_display_flight_id_ua_with_skywest_callsign():
+    assert display_flight_id(flight_number="UA5510", callsign="SKW5510") == "UA5510"
+
+
+def test_display_flight_id_alaska_skywest():
+    assert display_flight_id(flight_number="AS3490", callsign="SKW3490") == "AS3490"
+
+
+def test_prefer_marketing_from_live_feed():
+    assert prefer_marketing_flight_id(
+        schedule_number="",
+        live_number="AS3490",
+        callsign="SKW3490",
+    ) == "AS3490"
+
+
+def test_prefer_marketing_over_operator_schedule():
+    assert prefer_marketing_flight_id(
+        schedule_number="SKW3490",
+        live_number="AS3490",
+        callsign="SKW3490",
+    ) == "AS3490"
+
+
+def test_prefer_schedule_when_already_iata():
+    assert prefer_marketing_flight_id(
+        schedule_number="AS3490",
+        live_number="AS3490",
+        callsign="SKW3490",
+    ) == "AS3490"

--- a/flightscnr/utilities/airline_branding.py
+++ b/flightscnr/utilities/airline_branding.py
@@ -89,6 +89,9 @@ IATA_TO_ICAO = {
     "VS": "VIR",
 }
 
+# ICAO airline prefix → passenger-facing IATA (UAL5510 → UA5510)
+ICAO_TO_IATA = {icao: iata for iata, icao in IATA_TO_ICAO.items()}
+
 
 def _normalize(code: str) -> str:
     return (code or "").strip().upper()
@@ -127,6 +130,43 @@ def marketing_brand_name(flight_id: str) -> str:
     return ""
 
 
+def _to_iata_flight_id(flight_id: str) -> str:
+    """Rewrite known ICAO airline prefixes to IATA (UAL5510 → UA5510).
+
+    Ambiguous regionals (SKW, RPA, …) and unknown prefixes are left unchanged.
+    """
+    fid = _normalize(flight_id)
+    if not fid or fid == "—":
+        return fid
+    if _iata_prefix(fid):
+        return fid
+    icao = _icao_prefix(fid)
+    if icao and icao in ICAO_TO_IATA:
+        return ICAO_TO_IATA[icao] + fid[3:]
+    return fid
+
+
+def prefer_marketing_flight_id(
+    *,
+    schedule_number: str = "",
+    live_number: str = "",
+    callsign: str = "",
+) -> str:
+    """Pick passenger-facing IATA number over ATC/operator callsign.
+
+    FR24 live feed ``extra_info.flight`` is often AS3490 while callsign/schedule
+    may still be SKW3490.
+    """
+    sched = _normalize(schedule_number)
+    live = _normalize(live_number)
+    cs = _normalize(callsign)
+    if live and _iata_prefix(live):
+        sched_op = _icao_prefix(sched) if sched else None
+        if not sched or sched == cs or sched_op in AMBIGUOUS_REGIONALS:
+            return live
+    return sched or live or ""
+
+
 def display_flight_id(
     *,
     flight_number: str = "",
@@ -135,13 +175,21 @@ def display_flight_id(
     """Return the passenger-facing flight ID (e.g. UA5796), not the operator callsign (SKW5796)."""
     fn = _normalize(flight_number)
     cs = _normalize(callsign)
+    chosen = ""
     if fn:
         operator = _icao_prefix(cs) if cs else None
         if operator in AMBIGUOUS_REGIONALS:
-            return fn
-        if fn != cs and (_iata_prefix(fn) or _marketing_icao_from_flight_id(fn)):
-            return fn
-    return cs or fn or "—"
+            chosen = fn
+        elif fn != cs and (_iata_prefix(fn) or _marketing_icao_from_flight_id(fn)):
+            chosen = fn
+        else:
+            # Prefer schedule/flight number when present (UAL1684 → UA1684 below).
+            chosen = fn
+    if not chosen:
+        chosen = cs or fn or "—"
+    if chosen == "—":
+        return "—"
+    return _to_iata_flight_id(chosen)
 
 
 def display_flight_id_for_flight(flight: dict) -> str:

--- a/flightscnr/utilities/fr24_client.py
+++ b/flightscnr/utilities/fr24_client.py
@@ -172,7 +172,12 @@ class LiveFlight:
 
         schedule = details.get("schedule_info", {})
 
-        self.number = schedule.get("flight_number", "") or self.callsign
+        # Prefer schedule IATA number; keep live-feed extra_info.flight if schedule blank.
+        sched_number = (schedule.get("flight_number", "") or "").strip()
+        if sched_number:
+            self.number = sched_number
+        elif not self.number:
+            self.number = self.callsign
         # Airline name from aircraft_info.registered_owners
         aircraft = details.get("aircraft_info", {})
         self.airline_name = aircraft.get("registered_owners", "") or ""
@@ -570,6 +575,8 @@ class FR24Client:
             callsign = getattr(f, 'callsign', '') or ''
             registration = (getattr(extra, 'reg', '') or '') if extra else ''
             aircraft_type = (getattr(extra, 'type', '') or '') if extra else ''
+            # IATA marketing flight number (e.g. AS3490) — distinct from ATC callsign (SKW3490).
+            iata_flight = (getattr(extra, 'flight', '') or '').strip().upper() if extra else ''
             vspeed = (getattr(extra, 'vspeed', 0) or 0) if extra else 0
             icao_hex = ""
             if extra is not None:
@@ -593,6 +600,10 @@ class FR24Client:
                 except Exception:
                     eta = 0
 
+            airline_iata = ""
+            if len(iata_flight) >= 3 and iata_flight[:2].isalpha() and iata_flight[2:3].isdigit():
+                airline_iata = iata_flight[:2]
+
             lf = LiveFlight(
                 flight_id=f"{f.flightid:x}" if f.flightid else "",
                 latitude=f.lat,
@@ -606,11 +617,12 @@ class FR24Client:
                 origin_airport_iata=origin_iata,
                 destination_airport_iata=destination_iata,
                 airline_icao=callsign[:3] if callsign and len(callsign) >= 3 and callsign[:3].isalpha() else "",
-                airline_iata="",
+                airline_iata=airline_iata,
                 aircraft_code=aircraft_type,
                 on_ground=f.on_ground,
                 eta=eta,
                 icao_hex=icao_hex,
+                number=iata_flight,
             )
             flights.append(lf)
         return flights

--- a/flightscnr/utilities/overhead.py
+++ b/flightscnr/utilities/overhead.py
@@ -22,6 +22,7 @@ from utilities.airline_branding import (
     IATA_TO_ICAO,
     MARKETING_BRANDS,
     marketing_brand_name,
+    prefer_marketing_flight_id,
     resolve_logo_icao,
 )
 from utilities.fr24_client import FR24Client, LiveFlight
@@ -410,9 +411,25 @@ def _enrich_entry_from_zone_feed(entry: dict, lf: LiveFlight, stats: dict | None
         entry["plane"] = plane
         enriched = True
 
+    # IATA marketing number from live-feed extra_info.flight (AS3490 vs SKW3490).
+    marketing = (getattr(lf, "number", "") or "").strip().upper()
+    if marketing and not (entry.get("flight_number") or entry.get("number") or "").strip():
+        entry["flight_number"] = marketing
+        entry["number"] = marketing
+        enriched = True
+    elif marketing:
+        if not (entry.get("flight_number") or "").strip():
+            entry["flight_number"] = marketing
+            enriched = True
+        if not (entry.get("number") or "").strip():
+            entry["number"] = marketing
+            enriched = True
+
     callsign = (entry.get("callsign") or lf.callsign or "").strip()
+    flight_number = (entry.get("flight_number") or entry.get("number") or marketing or "").strip()
     airline_icao = resolve_logo_icao(
         operator_icao=lf.airline_icao or "",
+        flight_number=flight_number,
         callsign=callsign,
     )
     owner_icao = airline_icao or entry.get("owner_icao") or ""
@@ -426,7 +443,7 @@ def _enrich_entry_from_zone_feed(entry: dict, lf: LiveFlight, stats: dict | None
         enriched = True
 
     if not (entry.get("airline") or "").strip():
-        brand = marketing_brand_name(callsign)
+        brand = marketing_brand_name(flight_number) or marketing_brand_name(callsign)
         if brand:
             entry["airline"] = brand
             enriched = True
@@ -1053,10 +1070,15 @@ class Overhead:
                         plane = self.safe_get(d, "aircraft", "model", "code", default="") or f.aircraft_code or ""
 
                         # Airline name: try local database first, then FR24's registered_owners
-                        flight_number = self.safe_get(d, "schedule_info", "flight_number", default="")
+                        # Prefer IATA marketing number (live-feed extra_info.flight / schedule).
+                        callsign = f.callsign or ""
+                        flight_number = prefer_marketing_flight_id(
+                            schedule_number=self.safe_get(d, "schedule_info", "flight_number", default=""),
+                            live_number=(getattr(f, "number", "") or "").strip(),
+                            callsign=callsign,
+                        )
                         airline_name = self.safe_get(d, "aircraft_info", "registered_owners", default="")
 
-                        callsign = f.callsign or ""
                         airline_icao = resolve_logo_icao(
                             operator_icao=f.airline_icao or "",
                             flight_number=flight_number,
@@ -1179,6 +1201,7 @@ class Overhead:
                             "airline": airline_name,
                             "plane": plane,
                             "flight_number": flight_number,
+                            "number": flight_number,
                             "origin": origin,
                             "origin_latitude": origin_lat,
                             "origin_longitude": origin_lon,
@@ -1877,10 +1900,10 @@ class Overhead:
                     airline_name=airline_name,
                 )
 
-            flight_number = (
-                match.number
-                or self.safe_get(flight_details, "schedule_info", "flight_number", default="")
-                or ""
+            flight_number = prefer_marketing_flight_id(
+                schedule_number=self.safe_get(flight_details, "schedule_info", "flight_number", default=""),
+                live_number=match.number or "",
+                callsign=display_callsign,
             )
             airline_icao = resolve_logo_icao(
                 operator_icao=match.airline_icao or "",


### PR DESCRIPTION
## Summary
- Prefer FR24 marketing flight numbers (e.g. AS3490) over operator callsigns (SKW3490) on radar tags
- Rewrite known ICAO prefixes to IATA (UAL34 → UA34)