### PR TITLE
Fix Follow weather overlay lagging behind the basemap

### DIFF
--- a/flightscnr/display/round_touch/rainviewer_overlay.py
+++ b/flightscnr/display/round_touch/rainviewer_overlay.py
@@ -672,9 +672,10 @@ def invalidate() -> None:
         _meta_ts = 0.0
     _provider_fail_until.clear()
     with _follow_lock:
-        global _follow_viewport, _follow_loading
+        global _follow_viewport, _follow_loading, _follow_loading_started
         _follow_viewport = None
         _follow_loading = False
+        _follow_loading_started = 0.0
 
 
 def cache_token() -> object:
@@ -751,12 +752,18 @@ def attribution_text() -> str | None:
 _follow_lock = threading.Lock()
 _follow_viewport: dict[str, Any] | None = None
 _follow_loading = False
+_follow_loading_started = 0.0
+_follow_clamp_log_at = 0.0
 
-# Match live_map overscan so rain has headroom to pan until sticky refetch.
-_FOLLOW_OVERSCAN = 1.8
-_FOLLOW_STICKY_MARGIN = 0.55  # of overscanned half-span
+# Match live_map overscan / sticky margin so rain refetches *before* the crop
+# clamps. Margin above ``1 - 1/OVERSCAN`` freezes precip under a centered
+# plane while the basemap keeps panning — classic Follow weather lag.
+_FOLLOW_OVERSCAN = 2.2
+_FOLLOW_STICKY_MARGIN = (1.0 - 1.0 / _FOLLOW_OVERSCAN) * 0.65
 _FOLLOW_RADIUS_HYST_KM = 2.0
 _FOLLOW_RADIUS_HYST_FRAC = 0.15
+# Abandon a hung Follow rain fetch so the next frame can retry.
+_FOLLOW_INFLIGHT_STALE_S = 18.0
 
 
 def _follow_bounds_for_center(
@@ -780,6 +787,8 @@ def _follow_needs_refetch(
 ) -> bool:
     """True when the sticky rain raster should be rebuilt."""
     if vp is None or vp.get("raster") is None:
+        return True
+    if vp.get("force_refresh"):
         return True
     if frame_time is not None and int(vp.get("frame_time") or 0) != int(frame_time):
         return True
@@ -866,10 +875,13 @@ def _crop_follow_window(
     lon: float,
     panel_w: int,
     panel_h: int,
-) -> tuple[pygame.Surface, int, int] | None:
+) -> tuple[pygame.Surface, int, int, int, int] | None:
     """Crop a panel-sized (pre-scale) window from the sticky rain raster.
 
-    Returns ``(window_surface, crop_x, crop_y)`` in raster pixel space, or None.
+    Returns ``(window_surface, crop_x, crop_y, ideal_x, ideal_y)`` in raster
+    pixel space, or None. Ideal coords are the unclamped crop origin — when
+    they diverge from the clamped origin the rain freezes relative to the
+    plane and the caller must force a sticky refetch.
     Window size is ``raster / OVERSCAN`` so scaling to the panel shows
     ``radius_km`` geographically (matching the sticky fetch).
     """
@@ -908,10 +920,10 @@ def _crop_follow_window(
             win_w = max(8, int(round(win_h * aspect)))
         else:
             win_h = max(8, int(round(win_w / aspect)))
-    crop_x = int(round(px - win_w / 2))
-    crop_y = int(round(py - win_h / 2))
-    crop_x = max(0, min(crop_x, raster_w - win_w))
-    crop_y = max(0, min(crop_y, raster_h - win_h))
+    ideal_x = int(round(px - win_w / 2))
+    ideal_y = int(round(py - win_h / 2))
+    crop_x = max(0, min(ideal_x, raster_w - win_w))
+    crop_y = max(0, min(ideal_y, raster_h - win_h))
     rect = pygame.Rect(crop_x, crop_y, win_w, win_h).clip(raster.get_rect())
     if rect.w <= 0 or rect.h <= 0:
         return None
@@ -920,11 +932,36 @@ def _crop_follow_window(
         padded = pygame.Surface((win_w, win_h), pygame.SRCALPHA)
         padded.blit(window, (0, 0))
         window = padded
-    return window, crop_x, crop_y
+    return window, crop_x, crop_y, ideal_x, ideal_y
+
+
+def _start_follow_worker(lat: float, lon: float, radius_km: float) -> None:
+    """Kick a Follow rain rebuild if one is not already running (or stalled)."""
+    global _follow_loading, _follow_loading_started
+    now = time.time()
+    with _follow_lock:
+        if _follow_loading:
+            started = float(_follow_loading_started or 0.0)
+            if started > 0 and (now - started) < _FOLLOW_INFLIGHT_STALE_S:
+                return
+            logger.warning(
+                "[follow] precip fetch stalled after %.0fs; retrying",
+                (now - started) if started else -1,
+            )
+            _follow_loading = False
+            _follow_loading_started = 0.0
+        _follow_loading = True
+        _follow_loading_started = now
+    threading.Thread(
+        target=_follow_worker,
+        args=(lat, lon, radius_km),
+        daemon=True,
+        name="follow-rain",
+    ).start()
 
 
 def _follow_worker(lat: float, lon: float, radius_km: float) -> None:
-    global _follow_viewport, _follow_loading
+    global _follow_viewport, _follow_loading, _follow_loading_started
     try:
         meta, provider_id = _cached_metadata()
         if meta is None or not provider_id or _metadata_stale():
@@ -966,6 +1003,7 @@ def _follow_worker(lat: float, lon: float, radius_km: float) -> None:
     finally:
         with _follow_lock:
             _follow_loading = False
+            _follow_loading_started = 0.0
 
 
 def blit_follow_overlay(
@@ -982,7 +1020,7 @@ def blit_follow_overlay(
     Pans a sticky overscanned rain raster under the aircraft each frame so
     precip stays locked to the basemap while the plane is centered.
     """
-    global _follow_loading
+    global _follow_clamp_log_at
     if not _enabled():
         return
     try:
@@ -1000,21 +1038,9 @@ def blit_follow_overlay(
 
     with _follow_lock:
         vp = _follow_viewport
-        loading = _follow_loading
 
-    if (
-        _follow_needs_refetch(vp, lat, lon, radius_km, frame_time, provider_id)
-        and not loading
-    ):
-        with _follow_lock:
-            if not _follow_loading:
-                _follow_loading = True
-                threading.Thread(
-                    target=_follow_worker,
-                    args=(lat, lon, radius_km),
-                    daemon=True,
-                    name="follow-rain",
-                ).start()
+    if _follow_needs_refetch(vp, lat, lon, radius_km, frame_time, provider_id):
+        _start_follow_worker(lat, lon, radius_km)
 
     with _follow_lock:
         vp = _follow_viewport
@@ -1024,7 +1050,23 @@ def blit_follow_overlay(
     cropped = _crop_follow_window(vp, lat, lon, width, height)
     if cropped is None:
         return
-    window, _crop_x, _crop_y = cropped
+    window, crop_x, crop_y, ideal_x, ideal_y = cropped
+    # Clamped crop = precip freezes under a centered icon while basemap pans.
+    if abs(crop_x - ideal_x) > 2 or abs(crop_y - ideal_y) > 2:
+        now_clamp = time.time()
+        if now_clamp - _follow_clamp_log_at >= 5.0:
+            _follow_clamp_log_at = now_clamp
+            logger.warning(
+                "[follow] precip crop clamped (ideal=%d,%d got=%d,%d) — refetching",
+                ideal_x,
+                ideal_y,
+                crop_x,
+                crop_y,
+            )
+        with _follow_lock:
+            if _follow_viewport is not None:
+                _follow_viewport["force_refresh"] = True
+        _start_follow_worker(lat, lon, radius_km)
     try:
         scaled = pygame.transform.smoothscale(window, (side, side))
     except pygame.error:

--- a/flightscnr/tests/test_rainviewer_rate_limit.py
+++ b/flightscnr/tests/test_rainviewer_rate_limit.py
@@ -280,8 +280,8 @@ class TestFollowRainPan(unittest.TestCase):
         drifted = rv._crop_follow_window(vp, lat + 0.05, lon, 100, 100)
         self.assertIsNotNone(at_center)
         self.assertIsNotNone(drifted)
-        _, cx0, cy0 = at_center
-        _, cx1, cy1 = drifted
+        _, cx0, cy0, _, _ = at_center
+        _, cx1, cy1, _, _ = drifted
         # Northward drift → crop moves up in mercator (smaller y).
         self.assertNotEqual((cx0, cy0), (cx1, cy1))
         self.assertLess(cy1, cy0)
@@ -310,6 +310,50 @@ class TestFollowRainPan(unittest.TestCase):
         self.assertTrue(
             rv._follow_needs_refetch(vp, lat, lon, 40.0, 1000, "rainviewer")
         )
+
+    def test_sticky_margin_refetches_before_crop_clamp(self):
+        """Regression: margin above clamp fraction froze rain under the plane."""
+        from display.round_touch import rainviewer_overlay as rv
+
+        clamp_frac = 1.0 - 1.0 / rv._FOLLOW_OVERSCAN
+        self.assertLess(rv._FOLLOW_STICKY_MARGIN, clamp_frac)
+
+    def test_force_refresh_needs_refetch(self):
+        from display.round_touch import rainviewer_overlay as rv
+
+        lat, lon = 47.45, -122.31
+        vp = self._seed_viewport(lat, lon, 20.0)
+        vp["force_refresh"] = True
+        self.assertTrue(
+            rv._follow_needs_refetch(vp, lat, lon, 20.0, 1000, "rainviewer")
+        )
+
+    def test_crop_clamp_sets_force_refresh(self):
+        """When the crop hits the raster edge, force a sticky rain refetch."""
+        import pygame
+        from display.round_touch import rainviewer_overlay as rv
+        from unittest import mock
+
+        lat, lon = 47.45, -122.31
+        vp = self._seed_viewport(lat, lon, 20.0)
+        # Far outside overscan → crop clamps.
+        far_lat = lat + 2.0
+        cropped = rv._crop_follow_window(vp, far_lat, lon, 100, 100)
+        self.assertIsNotNone(cropped)
+        _window, crop_x, crop_y, ideal_x, ideal_y = cropped
+        self.assertTrue(abs(crop_x - ideal_x) > 2 or abs(crop_y - ideal_y) > 2)
+
+        surf = pygame.Surface((100, 100), pygame.SRCALPHA)
+        with mock.patch.object(rv, "_enabled", return_value=True), mock.patch(
+            "display.round_touch.settings.show_precipitation", return_value=True
+        ), mock.patch.object(rv, "_cached_metadata", return_value=(None, None)), mock.patch.object(
+            rv, "_start_follow_worker"
+        ) as start:
+            rv.blit_follow_overlay(
+                surf, lat=far_lat, lon=lon, radius_km=20.0, width=100, height=100
+            )
+        self.assertTrue(vp.get("force_refresh"))
+        start.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Follow screen, precipitation sometimes froze or slid relative to the satellite basemap while the aircraft stayed centered — matching the attached timelapse.

**Cause:** Follow rain used `_FOLLOW_OVERSCAN = 1.8` and `_FOLLOW_STICKY_MARGIN = 0.55`, which is past the crop-clamp fraction (`1 - 1/1.8 ≈ 0.44`). The basemap already uses overscan 2.2 with margin below its clamp, so rain hit the edge and stopped panning while the map kept moving.

## Fix

In `rainviewer_overlay.py`, mirror the live_map sticky-viewport rules:

- Match overscan (`2.2`) and sticky margin (`(1 - 1/OVERSCAN) * 0.65`)
- On crop clamp, set `force_refresh` and kick a rain rebuild
- Retry hung Follow rain fetches after an 18s stall timeout

## Tests

- Added regression: sticky margin must stay below clamp fraction
- Added `force_refresh` + crop-clamp → refetch coverage
- `tests.test_rainviewer_rate_limit` (incl. `TestFollowRainPan`) passes locally

License remains CC BY-NC-SA 4.0 (non-commercial).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02b8c-c8a8-7012-aece-e4d8f2ad0e56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02b8c-c8a8-7012-aece-e4d8f2ad0e56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

