### PR TITLE
Follow map: speed-based dynamic scaling (issue #114)

### DIFF
--- a/flightscnr/config.py
+++ b/flightscnr/config.py
@@ -180,13 +180,14 @@ POSITION_SOURCE_ORDER = _parse_position_source_order(
     os.environ.get("POSITION_SOURCE_ORDER", "")
 )
 
-# Extended live-tracking map (Radar > Track > Live): radius is
+# Extended live-tracking map (Radar > Track > Live / Follow): radius is
 # derived from current ground speed (distance covered in
-# LIVE_TRACKING_PREVIEW_MINUTES), clamped to [MIN, MAX]. MAX mirrors the
-# main-display radar outer band (50mi ≈ 80.5km).
+# LIVE_TRACKING_PREVIEW_MINUTES), with low-speed compression, then clamped
+# to [MIN, MAX]. Defaults span the Follow display-radius steps (3.2–120 km)
+# so taxi can zoom in and high-speed cruise can zoom out (issue #114).
 LIVE_TRACKING_PREVIEW_MINUTES = float(os.environ.get("LIVE_TRACKING_PREVIEW_MINUTES", "5"))
-LIVE_TRACKING_MIN_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MIN_RADIUS_KM", "8"))
-LIVE_TRACKING_MAX_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MAX_RADIUS_KM", "80.5"))
+LIVE_TRACKING_MIN_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MIN_RADIUS_KM", "3.2"))
+LIVE_TRACKING_MAX_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MAX_RADIUS_KM", "120"))
 
 # NASA FIRMS free MAP_KEY for wildfire detections on the radar.
 # https://firms.modaps.eosdis.nasa.gov/api/map_key/

--- a/flightscnr/display/round_touch/live_map.py
+++ b/flightscnr/display/round_touch/live_map.py
@@ -17,7 +17,7 @@ panning underneath it, following the aircraft in real time.
 Two things are deliberately NOT reused from route_map.py, because that
 module is tuned for a very different scale (a whole flown route, often
 hundreds of km) and both of its shortcuts break down at our scale
-(8-48km radius):
+(a few km through ~120 km radius, discrete Follow display steps):
 
 1. Zoom selection. route_map._pick_zoom() caps out at zoom 7 (fine for a
    continent-spanning route overview; far too coarse for a 8-48km circle
@@ -76,9 +76,29 @@ _INFLIGHT_STALE_S = 18.0
 # second; without this, sticky basemap refetches (triggered by position
 # drift) suddenly adopt a different speed-derived radius and the map
 # appears to "randomly" change zoom. Also ignore a missing/zero speed
-# reading so we don't snap to the 8km floor.
+# reading so we don't snap to the min-radius floor.
+#
+# Display scale uses discrete km steps (issue #114) with asymmetric
+# hysteresis between adjacent steps; continuous fractional hysteresis
+# below still gates sticky-viewport radius invalidation.
 _RADIUS_HYST_FRAC = 0.15
 _RADIUS_HYST_KM = 2.0
+
+# Discrete Follow display-radius steps (km). Search/preview radius from
+# position_source may be continuous; the visible map snaps to these.
+_LIVE_MAP_RADIUS_STEPS_KM = (
+    3.2,
+    4.8,
+    8.0,
+    13.0,
+    16.0,
+    24.0,
+    32.0,
+    48.0,
+    64.0,
+    96.0,
+    120.0,
+)
 
 # Zoom ceiling appropriate for this screen's scale (street/neighborhood
 # level), unlike route_map.py's z_hi=7 (continent-scale route overviews).
@@ -132,13 +152,67 @@ def lat_lon_to_follow_panel(lat: float, lon: float) -> tuple[float, float] | Non
         return None
 
 
+def _nearest_radius_step(raw_km: float) -> float:
+    """Smallest discrete step that covers ``raw_km`` (or the largest step)."""
+    raw = max(0.0, float(raw_km))
+    for step in _LIVE_MAP_RADIUS_STEPS_KM:
+        if raw <= step:
+            return step
+    return _LIVE_MAP_RADIUS_STEPS_KM[-1]
+
+
+def display_radius_km(
+    radius_km: float,
+    current_radius_km: float | None,
+) -> float:
+    """Snap Follow map scale to discrete steps with asymmetric hysteresis.
+
+    Zoom in early while slowing down (25% of the gap to the lower step);
+    zoom out conservatively while speeding up (90% of the gap to the
+    higher step). Transitions move at most one step per call so small
+    speed noise does not thrash the sticky basemap.
+    """
+    raw = max(0.0, float(radius_km))
+    steps = _LIVE_MAP_RADIUS_STEPS_KM
+
+    if current_radius_km is None:
+        return _nearest_radius_step(raw)
+
+    try:
+        current = float(current_radius_km)
+    except (TypeError, ValueError):
+        return _nearest_radius_step(raw)
+
+    try:
+        idx = steps.index(current)
+    except ValueError:
+        return _nearest_radius_step(raw)
+
+    # Zoom in early while slowing down.
+    if idx > 0:
+        lower = steps[idx - 1]
+        down_threshold = current - (current - lower) * 0.25
+        if raw <= down_threshold:
+            return lower
+
+    # Zoom out conservatively while speeding up.
+    if idx < len(steps) - 1:
+        higher = steps[idx + 1]
+        up_threshold = current + (higher - current) * 0.90
+        if raw >= up_threshold:
+            return higher
+
+    return current
+
+
 def stabilize_radius_km(
     previous: float, candidate: float, *, have_speed: bool
 ) -> float:
     """Hold Follow map zoom steady through noisy or missing ground speed.
 
     Returns ``previous`` when speed is missing/zero (avoid snapping to the
-    min-radius floor) or when ``candidate`` only moved within hysteresis.
+    min-radius floor). With a valid speed, maps ``candidate`` onto the
+    discrete display-radius steps with hysteresis (issue #114).
     """
     try:
         prev = float(previous)
@@ -147,14 +221,12 @@ def stabilize_radius_km(
     try:
         cand = float(candidate)
     except (TypeError, ValueError):
-        return prev if prev > 0 else 8.0
+        return prev if prev > 0 else _LIVE_MAP_RADIUS_STEPS_KM[2]  # 8.0 default
     if not have_speed:
-        return prev if prev > 0 else cand
+        return prev if prev > 0 else display_radius_km(cand, None)
     if prev <= 0:
-        return cand
-    if abs(cand - prev) < max(_RADIUS_HYST_KM, prev * _RADIUS_HYST_FRAC):
-        return prev
-    return cand
+        return display_radius_km(cand, None)
+    return display_radius_km(cand, prev)
 
 
 def _bounds_for_center(lat: float, lon: float, radius_km: float) -> tuple[float, float, float, float]:

--- a/flightscnr/tests/test_live_map.py
+++ b/flightscnr/tests/test_live_map.py
@@ -127,21 +127,46 @@ class TestStabilizeRadius(unittest.TestCase):
         from display.round_touch import live_map
 
         self.assertEqual(
-            live_map.stabilize_radius_km(22.0, 8.0, have_speed=False), 22.0
+            live_map.stabilize_radius_km(24.0, 8.0, have_speed=False), 24.0
         )
 
-    def test_ignores_small_jitter(self):
+    def test_snaps_to_discrete_step_on_first_fix(self):
         from display.round_touch import live_map
 
         self.assertEqual(
-            live_map.stabilize_radius_km(20.0, 21.5, have_speed=True), 20.0
+            live_map.stabilize_radius_km(0.0, 21.5, have_speed=True), 24.0
         )
 
-    def test_accepts_real_speed_change(self):
+    def test_ignores_small_jitter_within_step(self):
+        from display.round_touch import live_map
+
+        # At 16 km step, need raw >= 16 + (24-16)*0.9 = 23.2 to zoom out.
+        self.assertEqual(
+            live_map.stabilize_radius_km(16.0, 21.5, have_speed=True), 16.0
+        )
+
+    def test_zooms_out_one_step_when_crossing_up_threshold(self):
+        from display.round_touch import live_map
+
+        # 16 → 24 when raw clears 90% of the gap (23.2).
+        self.assertEqual(
+            live_map.stabilize_radius_km(16.0, 23.5, have_speed=True), 24.0
+        )
+
+    def test_zooms_in_early_when_slowing(self):
+        from display.round_touch import live_map
+
+        # At 16 km, down threshold = 16 - (16-13)*0.25 = 15.25.
+        self.assertEqual(
+            live_map.stabilize_radius_km(16.0, 15.0, have_speed=True), 13.0
+        )
+
+    def test_display_radius_steps_cover_issue_114_ladder(self):
         from display.round_touch import live_map
 
         self.assertEqual(
-            live_map.stabilize_radius_km(20.0, 35.0, have_speed=True), 35.0
+            live_map._LIVE_MAP_RADIUS_STEPS_KM,
+            (3.2, 4.8, 8.0, 13.0, 16.0, 24.0, 32.0, 48.0, 64.0, 96.0, 120.0),
         )
 
 

--- a/flightscnr/tests/test_position_source.py
+++ b/flightscnr/tests/test_position_source.py
@@ -26,21 +26,34 @@ class TestRadiusAndBBox(unittest.TestCase):
     def test_radius_floors_without_speed(self):
         from utilities import position_source
 
-        self.assertEqual(position_source.compute_tracking_radius_km(None), 8.0)
-        self.assertEqual(position_source.compute_tracking_radius_km(0), 8.0)
-        self.assertEqual(position_source.compute_tracking_radius_km(-10), 8.0)
+        self.assertEqual(position_source.compute_tracking_radius_km(None), 3.2)
+        self.assertEqual(position_source.compute_tracking_radius_km(0), 3.2)
+        self.assertEqual(position_source.compute_tracking_radius_km(-10), 3.2)
+
+    def test_low_speed_scale_curve(self):
+        from utilities import position_source
+
+        self.assertAlmostEqual(position_source._low_speed_scale(50), 0.45)
+        self.assertAlmostEqual(position_source._low_speed_scale(100), 0.45)
+        self.assertAlmostEqual(position_source._low_speed_scale(200), 0.725)
+        self.assertAlmostEqual(position_source._low_speed_scale(300), 1.0)
+        self.assertAlmostEqual(position_source._low_speed_scale(450), 1.0)
 
     def test_radius_scales_with_speed_and_clamps(self):
         from utilities import position_source
 
-        # 100 kt * 1.852 km/h * (5/60)h ≈ 15.43 km
+        # 100 kt * 1.852 * (5/60) * 0.45 ≈ 6.945 km (low-speed compression)
         r = position_source.compute_tracking_radius_km(100)
-        self.assertGreater(r, 8.0)
-        self.assertLess(r, 48.0)
-        self.assertAlmostEqual(r, 100 * 1.852 * (5.0 / 60.0), places=4)
+        self.assertGreater(r, 3.2)
+        self.assertLess(r, 120.0)
+        self.assertAlmostEqual(r, 100 * 1.852 * (5.0 / 60.0) * 0.45, places=4)
 
-        # Very fast → clamp to max (50mi radar band ≈ 80.5km)
-        self.assertEqual(position_source.compute_tracking_radius_km(2000), 80.5)
+        # Cruise: no compression (scale=1.0)
+        cruise = position_source.compute_tracking_radius_km(450)
+        self.assertAlmostEqual(cruise, 450 * 1.852 * (5.0 / 60.0), places=4)
+
+        # Very fast → clamp to max (Follow display step ceiling)
+        self.assertEqual(position_source.compute_tracking_radius_km(2000), 120.0)
 
     def test_bbox_symmetric_around_center(self):
         from utilities import position_source
@@ -101,12 +114,14 @@ class TestMatchAndFetch(unittest.TestCase):
                 icao24="ABCDEF",
                 last_known_lat=37.0,
                 last_known_lon=-122.0,
-                last_known_speed_kt=100,
+                last_known_speed_kt=300,
             )
         self.assertEqual(hits, ["dump1090", "adsbfi"])
         self.assertEqual(source, "adsbfi")
         self.assertIsNotNone(entry)
+        # 300 kt * 1.852 * 5/60 * 1.0 ≈ 46.3 km (within mocked 8–48 clamp)
         self.assertGreater(radius, 8.0)
+        self.assertAlmostEqual(radius, 300 * 1.852 * (5.0 / 60.0), places=4)
         record.assert_called_once_with("adsbfi")
 
     def test_fetch_requires_identity(self):
@@ -121,7 +136,7 @@ class TestMatchAndFetch(unittest.TestCase):
         )
         self.assertIsNone(entry)
         self.assertIsNone(source)
-        self.assertEqual(radius, 8.0)
+        self.assertEqual(radius, 3.2)
 
     def test_fr24_flight_to_entry_maps_fields(self):
         from utilities import position_source

--- a/flightscnr/utilities/position_source.py
+++ b/flightscnr/utilities/position_source.py
@@ -22,11 +22,14 @@ by their client modules. Default order prefers local/free sources
 the portal order is authoritative when the user reorders or omits entries.
 
 radius/bbox: the live-map radius is derived from the aircraft's last known
-ground speed (distance covered in LIVE_TRACKING_PREVIEW_MINUTES), clamped
-to [LIVE_TRACKING_MIN_RADIUS_KM, LIVE_TRACKING_MAX_RADIUS_KM]. This radius
+ground speed (distance covered in LIVE_TRACKING_PREVIEW_MINUTES), with
+low-speed compression for approach/taxi, then clamped to
+[LIVE_TRACKING_MIN_RADIUS_KM, LIVE_TRACKING_MAX_RADIUS_KM]. This radius
 is used both for the OpenSky/ADS-B Exchange bounding box (smaller box =
 fewer credits) and should be reused by the live-map renderer so the map's
-visible extent always matches what was actually queried.
+visible extent always matches what was actually queried. The Follow
+display further snaps that continuous radius to discrete km steps with
+hysteresis (see live_map.display_radius_km / stabilize_radius_km).
 """
 
 from __future__ import annotations
@@ -61,20 +64,43 @@ def _settings():
         min_km = LIVE_TRACKING_MIN_RADIUS_KM
         max_km = LIVE_TRACKING_MAX_RADIUS_KM
     except Exception:
-        preview_min, min_km, max_km = 5.0, 8.0, 48.0
+        preview_min, min_km, max_km = 5.0, 3.2, 120.0
 
     return order, preview_min, min_km, max_km
+
+
+def _low_speed_scale(speed_kt: float) -> float:
+    """Compress Follow map radius at approach/taxi speeds.
+
+    Keeps cruise (>=300 kt) on the linear preview-distance curve while
+    pulling the view in during approach and taxi (issue #114):
+
+        speed >= 300 kt → 1.0
+        speed <= 100 kt → 0.45
+        between          → linear from 0.45 to 1.0
+    """
+    if speed_kt >= 300.0:
+        return 1.0
+    if speed_kt <= 100.0:
+        return 0.45
+    return 0.45 + (speed_kt - 100.0) / 200.0 * 0.55
 
 
 def compute_tracking_radius_km(speed_kt: float | None) -> float:
     """Radius = distance the aircraft covers in the preview window,
     clamped to [min, max]. speed_kt is ground speed in knots (the unit
-    already used throughout this codebase, e.g. aircraft_min_speed_kt)."""
+    already used throughout this codebase, e.g. aircraft_min_speed_kt).
+
+    Applies low-speed compression so approach/landing/taxi get a closer
+    map than the raw projected distance alone would suggest.
+    """
     _, preview_min, min_km, max_km = _settings()
     if not speed_kt or speed_kt <= 0:
         return min_km
-    speed_kph = float(speed_kt) * KM_PER_NM
+    speed_kt_f = float(speed_kt)
+    speed_kph = speed_kt_f * KM_PER_NM
     projected_km = speed_kph * (preview_min / 60.0)
+    projected_km *= _low_speed_scale(speed_kt_f)
     return max(min_km, min(max_km, projected_km))
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Follow live-map improvements from #114 (ported from IronIBot’s tested approach):

1. **Low-speed compression** — approach/taxi use a closer map (`0.45×` at ≤100 kt, linear to `1.0×` by 300 kt).
2. **Discrete radius steps** — visible scale snaps to `3.2 … 120 km` with asymmetric hysteresis (zoom in early, zoom out conservatively) so ADS-B speed noise does not thrash sticky basemap fetches.
3. **Wider clamp defaults** — `LIVE_TRACKING_MIN/MAX_RADIUS_KM` default to `3.2` / `120` so taxi and high-speed cruise can reach the full step ladder.

The basic preview-distance formula was already on main; this completes the optional pieces from the issue.

## Tests

- `tests.test_position_source` (incl. low-speed scale curve)
- `tests.test_live_map` (incl. discrete-step hysteresis)

License remains CC BY-NC-SA 4.0 (non-commercial).

Closes #114
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03018-4771-7efe-87cf-69838b87b9e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03018-4771-7efe-87cf-69838b87b9e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

