### PR TITLE
Follow weather overlay lag + speed-based zoom (#114)

### DIFF
--- a/flightscnr/config.py
+++ b/flightscnr/config.py
@@ -180,13 +180,14 @@ POSITION_SOURCE_ORDER = _parse_position_source_order(
     os.environ.get("POSITION_SOURCE_ORDER", "")
 )
 
-# Extended live-tracking map (Radar > Track > Live): radius is
+# Extended live-tracking map (Radar > Track > Live / Follow): radius is
 # derived from current ground speed (distance covered in
-# LIVE_TRACKING_PREVIEW_MINUTES), clamped to [MIN, MAX]. MAX mirrors the
-# main-display radar outer band (50mi ≈ 80.5km).
+# LIVE_TRACKING_PREVIEW_MINUTES), with low-speed compression, then clamped
+# to [MIN, MAX]. Defaults span the Follow display-radius steps (3.2–120 km)
+# so taxi can zoom in and high-speed cruise can zoom out (issue #114).
 LIVE_TRACKING_PREVIEW_MINUTES = float(os.environ.get("LIVE_TRACKING_PREVIEW_MINUTES", "5"))
-LIVE_TRACKING_MIN_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MIN_RADIUS_KM", "8"))
-LIVE_TRACKING_MAX_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MAX_RADIUS_KM", "80.5"))
+LIVE_TRACKING_MIN_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MIN_RADIUS_KM", "3.2"))
+LIVE_TRACKING_MAX_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MAX_RADIUS_KM", "120"))
 
 # NASA FIRMS free MAP_KEY for wildfire detections on the radar.
 # https://firms.modaps.eosdis.nasa.gov/api/map_key/

--- a/flightscnr/config.py
+++ b/flightscnr/config.py
@@ -183,11 +183,13 @@ POSITION_SOURCE_ORDER = _parse_position_source_order(
 # Extended live-tracking map (Radar > Track > Live / Follow): radius is
 # derived from current ground speed (distance covered in
 # LIVE_TRACKING_PREVIEW_MINUTES), with low-speed compression, then clamped
-# to [MIN, MAX]. Defaults span the Follow display-radius steps (3.2–120 km)
-# so taxi can zoom in and high-speed cruise can zoom out (issue #114).
+# to [MIN, MAX]. MIN matches LIVE_TRACKING_TAXI_RADIUS_MI (2 mi ≈ 3.22 km).
 LIVE_TRACKING_PREVIEW_MINUTES = float(os.environ.get("LIVE_TRACKING_PREVIEW_MINUTES", "5"))
-LIVE_TRACKING_MIN_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MIN_RADIUS_KM", "3.2"))
+LIVE_TRACKING_MIN_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MIN_RADIUS_KM", "3.22"))
 LIVE_TRACKING_MAX_RADIUS_KM = float(os.environ.get("LIVE_TRACKING_MAX_RADIUS_KM", "120"))
+# Below this ground speed (kt), Follow uses a fixed map radius (mi).
+LIVE_TRACKING_TAXI_MAX_SPEED_KT = float(os.environ.get("LIVE_TRACKING_TAXI_MAX_SPEED_KT", "50"))
+LIVE_TRACKING_TAXI_RADIUS_MI = float(os.environ.get("LIVE_TRACKING_TAXI_RADIUS_MI", "2"))
 
 # NASA FIRMS free MAP_KEY for wildfire detections on the radar.
 # https://firms.modaps.eosdis.nasa.gov/api/map_key/

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -1011,16 +1011,19 @@ class RoundTouchDisplay:
             speed_f = float(speed) if speed is not None else None
         except (TypeError, ValueError):
             speed_f = None
-        have_speed = speed_f is not None and speed_f > 0
+        speed_known = speed_f is not None
+        taxi_snap = speed_known and position_source.is_taxi_speed_kt(speed_f)
+        prev_radius_km = self._live_map_last_radius_km
         radius_km = (
             position_source.compute_tracking_radius_km(speed_f)
-            if have_speed
+            if speed_known
             else self._live_map_last_radius_km
         )
         self._live_map_last_radius_km = live_map.stabilize_radius_km(
             self._live_map_last_radius_km,
             radius_km,
-            have_speed=have_speed,
+            have_speed=speed_known,
+            taxi_snap=taxi_snap,
         )
 
         source = display_data.get("data_source") or "tracked"
@@ -1057,7 +1060,7 @@ class RoundTouchDisplay:
         self._live_map_last_result = entry
         self._live_map_last_fetch = now
         self._live_map_inflight = False
-        if moved:
+        if moved or abs(self._live_map_last_radius_km - prev_radius_km) > 0.01:
             self._live_map_redraw = True
 
     def _draw_live_tracking(self, display_data: dict) -> None:
@@ -1542,8 +1545,10 @@ class RoundTouchDisplay:
             # Fresh entry into live tracking — force an immediate position fetch.
             self._live_map_last_fetch = 0.0
             self._live_map_last_result = None
+            # Snap Follow zoom from current speed (not the previous session's step).
+            self._live_map_last_radius_km = 0.0
             self._live_map_inflight = False
-            self._live_map_redraw = False
+            self._live_map_redraw = True
             self._follow_photo_open = False
             try:
                 live_map.invalidate()

--- a/flightscnr/display/round_touch/live_map.py
+++ b/flightscnr/display/round_touch/live_map.py
@@ -17,7 +17,7 @@ panning underneath it, following the aircraft in real time.
 Two things are deliberately NOT reused from route_map.py, because that
 module is tuned for a very different scale (a whole flown route, often
 hundreds of km) and both of its shortcuts break down at our scale
-(8-48km radius):
+(a few km through ~120 km radius, discrete Follow display steps):
 
 1. Zoom selection. route_map._pick_zoom() caps out at zoom 7 (fine for a
    continent-spanning route overview; far too coarse for a 8-48km circle
@@ -76,9 +76,29 @@ _INFLIGHT_STALE_S = 18.0
 # second; without this, sticky basemap refetches (triggered by position
 # drift) suddenly adopt a different speed-derived radius and the map
 # appears to "randomly" change zoom. Also ignore a missing/zero speed
-# reading so we don't snap to the 8km floor.
+# reading so we don't snap to the min-radius floor.
+#
+# Display scale uses discrete km steps (issue #114) with asymmetric
+# hysteresis between adjacent steps; continuous fractional hysteresis
+# below still gates sticky-viewport radius invalidation.
 _RADIUS_HYST_FRAC = 0.15
 _RADIUS_HYST_KM = 2.0
+
+# Discrete Follow display-radius steps (km). Search/preview radius from
+# position_source may be continuous; the visible map snaps to these.
+_LIVE_MAP_RADIUS_STEPS_KM = (
+    3.2,
+    4.8,
+    8.0,
+    13.0,
+    16.0,
+    24.0,
+    32.0,
+    48.0,
+    64.0,
+    96.0,
+    120.0,
+)
 
 # Zoom ceiling appropriate for this screen's scale (street/neighborhood
 # level), unlike route_map.py's z_hi=7 (continent-scale route overviews).
@@ -132,13 +152,67 @@ def lat_lon_to_follow_panel(lat: float, lon: float) -> tuple[float, float] | Non
         return None
 
 
+def _nearest_radius_step(raw_km: float) -> float:
+    """Smallest discrete step that covers ``raw_km`` (or the largest step)."""
+    raw = max(0.0, float(raw_km))
+    for step in _LIVE_MAP_RADIUS_STEPS_KM:
+        if raw <= step:
+            return step
+    return _LIVE_MAP_RADIUS_STEPS_KM[-1]
+
+
+def display_radius_km(
+    radius_km: float,
+    current_radius_km: float | None,
+) -> float:
+    """Snap Follow map scale to discrete steps with asymmetric hysteresis.
+
+    Zoom in early while slowing down (25% of the gap to the lower step);
+    zoom out conservatively while speeding up (90% of the gap to the
+    higher step). Transitions move at most one step per call so small
+    speed noise does not thrash the sticky basemap.
+    """
+    raw = max(0.0, float(radius_km))
+    steps = _LIVE_MAP_RADIUS_STEPS_KM
+
+    if current_radius_km is None:
+        return _nearest_radius_step(raw)
+
+    try:
+        current = float(current_radius_km)
+    except (TypeError, ValueError):
+        return _nearest_radius_step(raw)
+
+    try:
+        idx = steps.index(current)
+    except ValueError:
+        return _nearest_radius_step(raw)
+
+    # Zoom in early while slowing down.
+    if idx > 0:
+        lower = steps[idx - 1]
+        down_threshold = current - (current - lower) * 0.25
+        if raw <= down_threshold:
+            return lower
+
+    # Zoom out conservatively while speeding up.
+    if idx < len(steps) - 1:
+        higher = steps[idx + 1]
+        up_threshold = current + (higher - current) * 0.90
+        if raw >= up_threshold:
+            return higher
+
+    return current
+
+
 def stabilize_radius_km(
     previous: float, candidate: float, *, have_speed: bool
 ) -> float:
     """Hold Follow map zoom steady through noisy or missing ground speed.
 
     Returns ``previous`` when speed is missing/zero (avoid snapping to the
-    min-radius floor) or when ``candidate`` only moved within hysteresis.
+    min-radius floor). With a valid speed, maps ``candidate`` onto the
+    discrete display-radius steps with hysteresis (issue #114).
     """
     try:
         prev = float(previous)
@@ -147,14 +221,12 @@ def stabilize_radius_km(
     try:
         cand = float(candidate)
     except (TypeError, ValueError):
-        return prev if prev > 0 else 8.0
+        return prev if prev > 0 else _LIVE_MAP_RADIUS_STEPS_KM[2]  # 8.0 default
     if not have_speed:
-        return prev if prev > 0 else cand
+        return prev if prev > 0 else display_radius_km(cand, None)
     if prev <= 0:
-        return cand
-    if abs(cand - prev) < max(_RADIUS_HYST_KM, prev * _RADIUS_HYST_FRAC):
-        return prev
-    return cand
+        return display_radius_km(cand, None)
+    return display_radius_km(cand, prev)
 
 
 def _bounds_for_center(lat: float, lon: float, radius_km: float) -> tuple[float, float, float, float]:

--- a/flightscnr/display/round_touch/live_map.py
+++ b/flightscnr/display/round_touch/live_map.py
@@ -87,7 +87,7 @@ _RADIUS_HYST_KM = 2.0
 # Discrete Follow display-radius steps (km). Search/preview radius from
 # position_source may be continuous; the visible map snaps to these.
 _LIVE_MAP_RADIUS_STEPS_KM = (
-    3.2,
+    3.22,  # ~2 mi taxi / approach floor (issue #114)
     4.8,
     8.0,
     13.0,
@@ -206,13 +206,18 @@ def display_radius_km(
 
 
 def stabilize_radius_km(
-    previous: float, candidate: float, *, have_speed: bool
+    previous: float,
+    candidate: float,
+    *,
+    have_speed: bool,
+    taxi_snap: bool = False,
 ) -> float:
     """Hold Follow map zoom steady through noisy or missing ground speed.
 
-    Returns ``previous`` when speed is missing/zero (avoid snapping to the
-    min-radius floor). With a valid speed, maps ``candidate`` onto the
-    discrete display-radius steps with hysteresis (issue #114).
+    Returns ``previous`` when speed is missing. With a valid speed, maps
+    ``candidate`` onto the discrete display-radius steps with hysteresis
+    (issue #114). ``taxi_snap`` forces an immediate snap to the taxi step
+    (under 50 kt, including 0 kt on the ground).
     """
     try:
         prev = float(previous)
@@ -222,10 +227,24 @@ def stabilize_radius_km(
         cand = float(candidate)
     except (TypeError, ValueError):
         return prev if prev > 0 else _LIVE_MAP_RADIUS_STEPS_KM[2]  # 8.0 default
+    if taxi_snap:
+        return display_radius_km(cand, None)
     if not have_speed:
         return prev if prev > 0 else display_radius_km(cand, None)
     if prev <= 0:
         return display_radius_km(cand, None)
+    target = _nearest_radius_step(cand)
+    if target > prev:
+        steps = _LIVE_MAP_RADIUS_STEPS_KM
+        try:
+            prev_idx = steps.index(prev)
+            target_idx = steps.index(target)
+        except ValueError:
+            return display_radius_km(cand, prev)
+        # Large speed-up: snap to the target step in one poll. Small increases
+        # still use one-step hysteresis so ground-speed noise does not thrash.
+        if target_idx - prev_idx > 1:
+            return target
     return display_radius_km(cand, prev)
 
 

--- a/flightscnr/display/round_touch/rainviewer_overlay.py
+++ b/flightscnr/display/round_touch/rainviewer_overlay.py
@@ -672,9 +672,10 @@ def invalidate() -> None:
         _meta_ts = 0.0
     _provider_fail_until.clear()
     with _follow_lock:
-        global _follow_viewport, _follow_loading
+        global _follow_viewport, _follow_loading, _follow_loading_started
         _follow_viewport = None
         _follow_loading = False
+        _follow_loading_started = 0.0
 
 
 def cache_token() -> object:
@@ -751,12 +752,18 @@ def attribution_text() -> str | None:
 _follow_lock = threading.Lock()
 _follow_viewport: dict[str, Any] | None = None
 _follow_loading = False
+_follow_loading_started = 0.0
+_follow_clamp_log_at = 0.0
 
-# Match live_map overscan so rain has headroom to pan until sticky refetch.
-_FOLLOW_OVERSCAN = 1.8
-_FOLLOW_STICKY_MARGIN = 0.55  # of overscanned half-span
+# Match live_map overscan / sticky margin so rain refetches *before* the crop
+# clamps. Margin above ``1 - 1/OVERSCAN`` freezes precip under a centered
+# plane while the basemap keeps panning — classic Follow weather lag.
+_FOLLOW_OVERSCAN = 2.2
+_FOLLOW_STICKY_MARGIN = (1.0 - 1.0 / _FOLLOW_OVERSCAN) * 0.65
 _FOLLOW_RADIUS_HYST_KM = 2.0
 _FOLLOW_RADIUS_HYST_FRAC = 0.15
+# Abandon a hung Follow rain fetch so the next frame can retry.
+_FOLLOW_INFLIGHT_STALE_S = 18.0
 
 
 def _follow_bounds_for_center(
@@ -780,6 +787,8 @@ def _follow_needs_refetch(
 ) -> bool:
     """True when the sticky rain raster should be rebuilt."""
     if vp is None or vp.get("raster") is None:
+        return True
+    if vp.get("force_refresh"):
         return True
     if frame_time is not None and int(vp.get("frame_time") or 0) != int(frame_time):
         return True
@@ -866,10 +875,13 @@ def _crop_follow_window(
     lon: float,
     panel_w: int,
     panel_h: int,
-) -> tuple[pygame.Surface, int, int] | None:
+) -> tuple[pygame.Surface, int, int, int, int] | None:
     """Crop a panel-sized (pre-scale) window from the sticky rain raster.
 
-    Returns ``(window_surface, crop_x, crop_y)`` in raster pixel space, or None.
+    Returns ``(window_surface, crop_x, crop_y, ideal_x, ideal_y)`` in raster
+    pixel space, or None. Ideal coords are the unclamped crop origin — when
+    they diverge from the clamped origin the rain freezes relative to the
+    plane and the caller must force a sticky refetch.
     Window size is ``raster / OVERSCAN`` so scaling to the panel shows
     ``radius_km`` geographically (matching the sticky fetch).
     """
@@ -908,10 +920,10 @@ def _crop_follow_window(
             win_w = max(8, int(round(win_h * aspect)))
         else:
             win_h = max(8, int(round(win_w / aspect)))
-    crop_x = int(round(px - win_w / 2))
-    crop_y = int(round(py - win_h / 2))
-    crop_x = max(0, min(crop_x, raster_w - win_w))
-    crop_y = max(0, min(crop_y, raster_h - win_h))
+    ideal_x = int(round(px - win_w / 2))
+    ideal_y = int(round(py - win_h / 2))
+    crop_x = max(0, min(ideal_x, raster_w - win_w))
+    crop_y = max(0, min(ideal_y, raster_h - win_h))
     rect = pygame.Rect(crop_x, crop_y, win_w, win_h).clip(raster.get_rect())
     if rect.w <= 0 or rect.h <= 0:
         return None
@@ -920,11 +932,36 @@ def _crop_follow_window(
         padded = pygame.Surface((win_w, win_h), pygame.SRCALPHA)
         padded.blit(window, (0, 0))
         window = padded
-    return window, crop_x, crop_y
+    return window, crop_x, crop_y, ideal_x, ideal_y
+
+
+def _start_follow_worker(lat: float, lon: float, radius_km: float) -> None:
+    """Kick a Follow rain rebuild if one is not already running (or stalled)."""
+    global _follow_loading, _follow_loading_started
+    now = time.time()
+    with _follow_lock:
+        if _follow_loading:
+            started = float(_follow_loading_started or 0.0)
+            if started > 0 and (now - started) < _FOLLOW_INFLIGHT_STALE_S:
+                return
+            logger.warning(
+                "[follow] precip fetch stalled after %.0fs; retrying",
+                (now - started) if started else -1,
+            )
+            _follow_loading = False
+            _follow_loading_started = 0.0
+        _follow_loading = True
+        _follow_loading_started = now
+    threading.Thread(
+        target=_follow_worker,
+        args=(lat, lon, radius_km),
+        daemon=True,
+        name="follow-rain",
+    ).start()
 
 
 def _follow_worker(lat: float, lon: float, radius_km: float) -> None:
-    global _follow_viewport, _follow_loading
+    global _follow_viewport, _follow_loading, _follow_loading_started
     try:
         meta, provider_id = _cached_metadata()
         if meta is None or not provider_id or _metadata_stale():
@@ -966,6 +1003,7 @@ def _follow_worker(lat: float, lon: float, radius_km: float) -> None:
     finally:
         with _follow_lock:
             _follow_loading = False
+            _follow_loading_started = 0.0
 
 
 def blit_follow_overlay(
@@ -982,7 +1020,7 @@ def blit_follow_overlay(
     Pans a sticky overscanned rain raster under the aircraft each frame so
     precip stays locked to the basemap while the plane is centered.
     """
-    global _follow_loading
+    global _follow_clamp_log_at
     if not _enabled():
         return
     try:
@@ -1000,21 +1038,9 @@ def blit_follow_overlay(
 
     with _follow_lock:
         vp = _follow_viewport
-        loading = _follow_loading
 
-    if (
-        _follow_needs_refetch(vp, lat, lon, radius_km, frame_time, provider_id)
-        and not loading
-    ):
-        with _follow_lock:
-            if not _follow_loading:
-                _follow_loading = True
-                threading.Thread(
-                    target=_follow_worker,
-                    args=(lat, lon, radius_km),
-                    daemon=True,
-                    name="follow-rain",
-                ).start()
+    if _follow_needs_refetch(vp, lat, lon, radius_km, frame_time, provider_id):
+        _start_follow_worker(lat, lon, radius_km)
 
     with _follow_lock:
         vp = _follow_viewport
@@ -1024,7 +1050,23 @@ def blit_follow_overlay(
     cropped = _crop_follow_window(vp, lat, lon, width, height)
     if cropped is None:
         return
-    window, _crop_x, _crop_y = cropped
+    window, crop_x, crop_y, ideal_x, ideal_y = cropped
+    # Clamped crop = precip freezes under a centered icon while basemap pans.
+    if abs(crop_x - ideal_x) > 2 or abs(crop_y - ideal_y) > 2:
+        now_clamp = time.time()
+        if now_clamp - _follow_clamp_log_at >= 5.0:
+            _follow_clamp_log_at = now_clamp
+            logger.warning(
+                "[follow] precip crop clamped (ideal=%d,%d got=%d,%d) — refetching",
+                ideal_x,
+                ideal_y,
+                crop_x,
+                crop_y,
+            )
+        with _follow_lock:
+            if _follow_viewport is not None:
+                _follow_viewport["force_refresh"] = True
+        _start_follow_worker(lat, lon, radius_km)
     try:
         scaled = pygame.transform.smoothscale(window, (side, side))
     except pygame.error:

--- a/flightscnr/tests/test_live_map.py
+++ b/flightscnr/tests/test_live_map.py
@@ -127,21 +127,46 @@ class TestStabilizeRadius(unittest.TestCase):
         from display.round_touch import live_map
 
         self.assertEqual(
-            live_map.stabilize_radius_km(22.0, 8.0, have_speed=False), 22.0
+            live_map.stabilize_radius_km(24.0, 8.0, have_speed=False), 24.0
         )
 
-    def test_ignores_small_jitter(self):
+    def test_snaps_to_discrete_step_on_first_fix(self):
         from display.round_touch import live_map
 
         self.assertEqual(
-            live_map.stabilize_radius_km(20.0, 21.5, have_speed=True), 20.0
+            live_map.stabilize_radius_km(0.0, 21.5, have_speed=True), 24.0
         )
 
-    def test_accepts_real_speed_change(self):
+    def test_ignores_small_jitter_within_step(self):
+        from display.round_touch import live_map
+
+        # At 16 km step, need raw >= 16 + (24-16)*0.9 = 23.2 to zoom out.
+        self.assertEqual(
+            live_map.stabilize_radius_km(16.0, 21.5, have_speed=True), 16.0
+        )
+
+    def test_zooms_out_one_step_when_crossing_up_threshold(self):
+        from display.round_touch import live_map
+
+        # 16 → 24 when raw clears 90% of the gap (23.2).
+        self.assertEqual(
+            live_map.stabilize_radius_km(16.0, 23.5, have_speed=True), 24.0
+        )
+
+    def test_zooms_in_early_when_slowing(self):
+        from display.round_touch import live_map
+
+        # At 16 km, down threshold = 16 - (16-13)*0.25 = 15.25.
+        self.assertEqual(
+            live_map.stabilize_radius_km(16.0, 15.0, have_speed=True), 13.0
+        )
+
+    def test_display_radius_steps_cover_issue_114_ladder(self):
         from display.round_touch import live_map
 
         self.assertEqual(
-            live_map.stabilize_radius_km(20.0, 35.0, have_speed=True), 35.0
+            live_map._LIVE_MAP_RADIUS_STEPS_KM,
+            (3.2, 4.8, 8.0, 13.0, 16.0, 24.0, 32.0, 48.0, 64.0, 96.0, 120.0),
         )
 
 

--- a/flightscnr/tests/test_live_map.py
+++ b/flightscnr/tests/test_live_map.py
@@ -161,12 +161,31 @@ class TestStabilizeRadius(unittest.TestCase):
             live_map.stabilize_radius_km(16.0, 15.0, have_speed=True), 13.0
         )
 
+    def test_catch_up_zoom_out_in_one_poll(self):
+        from display.round_touch import live_map
+
+        # Cruise raw ~62 km should land on 64 km, not creep 8→13→… over many polls.
+        self.assertEqual(
+            live_map.stabilize_radius_km(8.0, 62.0, have_speed=True), 64.0
+        )
+
+    def test_taxi_snap_from_approach_zoom(self):
+        from display.round_touch import live_map
+
+        # gs=0 on the ground must snap to 2 mi, not hold approach zoom.
+        self.assertEqual(
+            live_map.stabilize_radius_km(
+                16.0, 3.22, have_speed=True, taxi_snap=True
+            ),
+            3.22,
+        )
+
     def test_display_radius_steps_cover_issue_114_ladder(self):
         from display.round_touch import live_map
 
         self.assertEqual(
             live_map._LIVE_MAP_RADIUS_STEPS_KM,
-            (3.2, 4.8, 8.0, 13.0, 16.0, 24.0, 32.0, 48.0, 64.0, 96.0, 120.0),
+            (3.22, 4.8, 8.0, 13.0, 16.0, 24.0, 32.0, 48.0, 64.0, 96.0, 120.0),
         )
 
 

--- a/flightscnr/tests/test_position_source.py
+++ b/flightscnr/tests/test_position_source.py
@@ -26,9 +26,26 @@ class TestRadiusAndBBox(unittest.TestCase):
     def test_radius_floors_without_speed(self):
         from utilities import position_source
 
-        self.assertEqual(position_source.compute_tracking_radius_km(None), 3.2)
-        self.assertEqual(position_source.compute_tracking_radius_km(0), 3.2)
-        self.assertEqual(position_source.compute_tracking_radius_km(-10), 3.2)
+        self.assertEqual(position_source.compute_tracking_radius_km(None), 3.22)
+        self.assertEqual(position_source.compute_tracking_radius_km(0), 3.22)
+        self.assertEqual(position_source.compute_tracking_radius_km(-10), 3.22)
+
+    def test_taxi_speed_uses_two_mile_radius(self):
+        from utilities import position_source
+
+        taxi_km = round(position_source._mi_to_km(2.0), 2)
+        self.assertEqual(taxi_km, 3.22)
+        for kt in (0, 5, 30, 49.9):
+            self.assertAlmostEqual(
+                position_source.compute_tracking_radius_km(kt),
+                taxi_km,
+                places=2,
+            )
+            self.assertTrue(position_source.is_taxi_speed_kt(kt))
+        # At exactly 50 kt the speed-based curve applies (not the taxi floor).
+        self.assertGreater(position_source.compute_tracking_radius_km(50), taxi_km)
+        self.assertFalse(position_source.is_taxi_speed_kt(50))
+        self.assertFalse(position_source.is_taxi_speed_kt(None))
 
     def test_low_speed_scale_curve(self):
         from utilities import position_source
@@ -44,7 +61,7 @@ class TestRadiusAndBBox(unittest.TestCase):
 
         # 100 kt * 1.852 * (5/60) * 0.45 ≈ 6.945 km (low-speed compression)
         r = position_source.compute_tracking_radius_km(100)
-        self.assertGreater(r, 3.2)
+        self.assertGreater(r, 3.22)
         self.assertLess(r, 120.0)
         self.assertAlmostEqual(r, 100 * 1.852 * (5.0 / 60.0) * 0.45, places=4)
 
@@ -136,7 +153,7 @@ class TestMatchAndFetch(unittest.TestCase):
         )
         self.assertIsNone(entry)
         self.assertIsNone(source)
-        self.assertEqual(radius, 3.2)
+        self.assertEqual(radius, 3.22)
 
     def test_fr24_flight_to_entry_maps_fields(self):
         from utilities import position_source

--- a/flightscnr/tests/test_position_source.py
+++ b/flightscnr/tests/test_position_source.py
@@ -26,21 +26,34 @@ class TestRadiusAndBBox(unittest.TestCase):
     def test_radius_floors_without_speed(self):
         from utilities import position_source
 
-        self.assertEqual(position_source.compute_tracking_radius_km(None), 8.0)
-        self.assertEqual(position_source.compute_tracking_radius_km(0), 8.0)
-        self.assertEqual(position_source.compute_tracking_radius_km(-10), 8.0)
+        self.assertEqual(position_source.compute_tracking_radius_km(None), 3.2)
+        self.assertEqual(position_source.compute_tracking_radius_km(0), 3.2)
+        self.assertEqual(position_source.compute_tracking_radius_km(-10), 3.2)
+
+    def test_low_speed_scale_curve(self):
+        from utilities import position_source
+
+        self.assertAlmostEqual(position_source._low_speed_scale(50), 0.45)
+        self.assertAlmostEqual(position_source._low_speed_scale(100), 0.45)
+        self.assertAlmostEqual(position_source._low_speed_scale(200), 0.725)
+        self.assertAlmostEqual(position_source._low_speed_scale(300), 1.0)
+        self.assertAlmostEqual(position_source._low_speed_scale(450), 1.0)
 
     def test_radius_scales_with_speed_and_clamps(self):
         from utilities import position_source
 
-        # 100 kt * 1.852 km/h * (5/60)h ≈ 15.43 km
+        # 100 kt * 1.852 * (5/60) * 0.45 ≈ 6.945 km (low-speed compression)
         r = position_source.compute_tracking_radius_km(100)
-        self.assertGreater(r, 8.0)
-        self.assertLess(r, 48.0)
-        self.assertAlmostEqual(r, 100 * 1.852 * (5.0 / 60.0), places=4)
+        self.assertGreater(r, 3.2)
+        self.assertLess(r, 120.0)
+        self.assertAlmostEqual(r, 100 * 1.852 * (5.0 / 60.0) * 0.45, places=4)
 
-        # Very fast → clamp to max (50mi radar band ≈ 80.5km)
-        self.assertEqual(position_source.compute_tracking_radius_km(2000), 80.5)
+        # Cruise: no compression (scale=1.0)
+        cruise = position_source.compute_tracking_radius_km(450)
+        self.assertAlmostEqual(cruise, 450 * 1.852 * (5.0 / 60.0), places=4)
+
+        # Very fast → clamp to max (Follow display step ceiling)
+        self.assertEqual(position_source.compute_tracking_radius_km(2000), 120.0)
 
     def test_bbox_symmetric_around_center(self):
         from utilities import position_source
@@ -101,12 +114,14 @@ class TestMatchAndFetch(unittest.TestCase):
                 icao24="ABCDEF",
                 last_known_lat=37.0,
                 last_known_lon=-122.0,
-                last_known_speed_kt=100,
+                last_known_speed_kt=300,
             )
         self.assertEqual(hits, ["dump1090", "adsbfi"])
         self.assertEqual(source, "adsbfi")
         self.assertIsNotNone(entry)
+        # 300 kt * 1.852 * 5/60 * 1.0 ≈ 46.3 km (within mocked 8–48 clamp)
         self.assertGreater(radius, 8.0)
+        self.assertAlmostEqual(radius, 300 * 1.852 * (5.0 / 60.0), places=4)
         record.assert_called_once_with("adsbfi")
 
     def test_fetch_requires_identity(self):
@@ -121,7 +136,7 @@ class TestMatchAndFetch(unittest.TestCase):
         )
         self.assertIsNone(entry)
         self.assertIsNone(source)
-        self.assertEqual(radius, 8.0)
+        self.assertEqual(radius, 3.2)
 
     def test_fr24_flight_to_entry_maps_fields(self):
         from utilities import position_source

--- a/flightscnr/tests/test_rainviewer_rate_limit.py
+++ b/flightscnr/tests/test_rainviewer_rate_limit.py
@@ -280,8 +280,8 @@ class TestFollowRainPan(unittest.TestCase):
         drifted = rv._crop_follow_window(vp, lat + 0.05, lon, 100, 100)
         self.assertIsNotNone(at_center)
         self.assertIsNotNone(drifted)
-        _, cx0, cy0 = at_center
-        _, cx1, cy1 = drifted
+        _, cx0, cy0, _, _ = at_center
+        _, cx1, cy1, _, _ = drifted
         # Northward drift → crop moves up in mercator (smaller y).
         self.assertNotEqual((cx0, cy0), (cx1, cy1))
         self.assertLess(cy1, cy0)
@@ -310,6 +310,50 @@ class TestFollowRainPan(unittest.TestCase):
         self.assertTrue(
             rv._follow_needs_refetch(vp, lat, lon, 40.0, 1000, "rainviewer")
         )
+
+    def test_sticky_margin_refetches_before_crop_clamp(self):
+        """Regression: margin above clamp fraction froze rain under the plane."""
+        from display.round_touch import rainviewer_overlay as rv
+
+        clamp_frac = 1.0 - 1.0 / rv._FOLLOW_OVERSCAN
+        self.assertLess(rv._FOLLOW_STICKY_MARGIN, clamp_frac)
+
+    def test_force_refresh_needs_refetch(self):
+        from display.round_touch import rainviewer_overlay as rv
+
+        lat, lon = 47.45, -122.31
+        vp = self._seed_viewport(lat, lon, 20.0)
+        vp["force_refresh"] = True
+        self.assertTrue(
+            rv._follow_needs_refetch(vp, lat, lon, 20.0, 1000, "rainviewer")
+        )
+
+    def test_crop_clamp_sets_force_refresh(self):
+        """When the crop hits the raster edge, force a sticky rain refetch."""
+        import pygame
+        from display.round_touch import rainviewer_overlay as rv
+        from unittest import mock
+
+        lat, lon = 47.45, -122.31
+        vp = self._seed_viewport(lat, lon, 20.0)
+        # Far outside overscan → crop clamps.
+        far_lat = lat + 2.0
+        cropped = rv._crop_follow_window(vp, far_lat, lon, 100, 100)
+        self.assertIsNotNone(cropped)
+        _window, crop_x, crop_y, ideal_x, ideal_y = cropped
+        self.assertTrue(abs(crop_x - ideal_x) > 2 or abs(crop_y - ideal_y) > 2)
+
+        surf = pygame.Surface((100, 100), pygame.SRCALPHA)
+        with mock.patch.object(rv, "_enabled", return_value=True), mock.patch(
+            "display.round_touch.settings.show_precipitation", return_value=True
+        ), mock.patch.object(rv, "_cached_metadata", return_value=(None, None)), mock.patch.object(
+            rv, "_start_follow_worker"
+        ) as start:
+            rv.blit_follow_overlay(
+                surf, lat=far_lat, lon=lon, radius_km=20.0, width=100, height=100
+            )
+        self.assertTrue(vp.get("force_refresh"))
+        start.assert_called()
 
 
 if __name__ == "__main__":

--- a/flightscnr/utilities/position_source.py
+++ b/flightscnr/utilities/position_source.py
@@ -22,11 +22,14 @@ by their client modules. Default order prefers local/free sources
 the portal order is authoritative when the user reorders or omits entries.
 
 radius/bbox: the live-map radius is derived from the aircraft's last known
-ground speed (distance covered in LIVE_TRACKING_PREVIEW_MINUTES), clamped
-to [LIVE_TRACKING_MIN_RADIUS_KM, LIVE_TRACKING_MAX_RADIUS_KM]. This radius
+ground speed (distance covered in LIVE_TRACKING_PREVIEW_MINUTES), with
+low-speed compression for approach/taxi, then clamped to
+[LIVE_TRACKING_MIN_RADIUS_KM, LIVE_TRACKING_MAX_RADIUS_KM]. This radius
 is used both for the OpenSky/ADS-B Exchange bounding box (smaller box =
 fewer credits) and should be reused by the live-map renderer so the map's
-visible extent always matches what was actually queried.
+visible extent always matches what was actually queried. The Follow
+display further snaps that continuous radius to discrete km steps with
+hysteresis (see live_map.display_radius_km / stabilize_radius_km).
 """
 
 from __future__ import annotations
@@ -61,20 +64,43 @@ def _settings():
         min_km = LIVE_TRACKING_MIN_RADIUS_KM
         max_km = LIVE_TRACKING_MAX_RADIUS_KM
     except Exception:
-        preview_min, min_km, max_km = 5.0, 8.0, 48.0
+        preview_min, min_km, max_km = 5.0, 3.2, 120.0
 
     return order, preview_min, min_km, max_km
+
+
+def _low_speed_scale(speed_kt: float) -> float:
+    """Compress Follow map radius at approach/taxi speeds.
+
+    Keeps cruise (>=300 kt) on the linear preview-distance curve while
+    pulling the view in during approach and taxi (issue #114):
+
+        speed >= 300 kt → 1.0
+        speed <= 100 kt → 0.45
+        between          → linear from 0.45 to 1.0
+    """
+    if speed_kt >= 300.0:
+        return 1.0
+    if speed_kt <= 100.0:
+        return 0.45
+    return 0.45 + (speed_kt - 100.0) / 200.0 * 0.55
 
 
 def compute_tracking_radius_km(speed_kt: float | None) -> float:
     """Radius = distance the aircraft covers in the preview window,
     clamped to [min, max]. speed_kt is ground speed in knots (the unit
-    already used throughout this codebase, e.g. aircraft_min_speed_kt)."""
+    already used throughout this codebase, e.g. aircraft_min_speed_kt).
+
+    Applies low-speed compression so approach/landing/taxi get a closer
+    map than the raw projected distance alone would suggest.
+    """
     _, preview_min, min_km, max_km = _settings()
     if not speed_kt or speed_kt <= 0:
         return min_km
-    speed_kph = float(speed_kt) * KM_PER_NM
+    speed_kt_f = float(speed_kt)
+    speed_kph = speed_kt_f * KM_PER_NM
     projected_km = speed_kph * (preview_min / 60.0)
+    projected_km *= _low_speed_scale(speed_kt_f)
     return max(min_km, min(max_km, projected_km))
 
 

--- a/flightscnr/utilities/position_source.py
+++ b/flightscnr/utilities/position_source.py
@@ -23,7 +23,8 @@ the portal order is authoritative when the user reorders or omits entries.
 
 radius/bbox: the live-map radius is derived from the aircraft's last known
 ground speed (distance covered in LIVE_TRACKING_PREVIEW_MINUTES), with
-low-speed compression for approach/taxi, then clamped to
+a fixed taxi/approach radius below LIVE_TRACKING_TAXI_MAX_SPEED_KT, then
+low-speed compression above that, then clamped to
 [LIVE_TRACKING_MIN_RADIUS_KM, LIVE_TRACKING_MAX_RADIUS_KM]. This radius
 is used both for the OpenSky/ADS-B Exchange bounding box (smaller box =
 fewer credits) and should be reused by the live-map renderer so the map's
@@ -40,7 +41,32 @@ import math
 logger = logging.getLogger(__name__)
 
 KM_PER_NM = 1.852
+KM_PER_MI = 1.609344
 KM_PER_DEGREE_LAT = 111.0
+
+# Follow taxi / approach floor (issue #114): under LIVE_TRACKING_TAXI_MAX_SPEED_KT
+# the visible map radius is fixed at LIVE_TRACKING_TAXI_RADIUS_MI.
+_DEFAULT_TAXI_MAX_SPEED_KT = 50.0
+_DEFAULT_TAXI_RADIUS_MI = 2.0
+
+
+def _mi_to_km(mi: float) -> float:
+    return float(mi) * KM_PER_MI
+
+
+def _taxi_settings() -> tuple[float, float]:
+    """(max_speed_kt, radius_km) for fixed close-in Follow view."""
+    try:
+        from config import (
+            LIVE_TRACKING_TAXI_MAX_SPEED_KT,
+            LIVE_TRACKING_TAXI_RADIUS_MI,
+        )
+
+        return float(LIVE_TRACKING_TAXI_MAX_SPEED_KT), _mi_to_km(
+            float(LIVE_TRACKING_TAXI_RADIUS_MI)
+        )
+    except Exception:
+        return _DEFAULT_TAXI_MAX_SPEED_KT, _mi_to_km(_DEFAULT_TAXI_RADIUS_MI)
 
 
 def _settings():
@@ -64,7 +90,7 @@ def _settings():
         min_km = LIVE_TRACKING_MIN_RADIUS_KM
         max_km = LIVE_TRACKING_MAX_RADIUS_KM
     except Exception:
-        preview_min, min_km, max_km = 5.0, 3.2, 120.0
+        preview_min, min_km, max_km = 5.0, 3.22, 120.0
 
     return order, preview_min, min_km, max_km
 
@@ -86,18 +112,32 @@ def _low_speed_scale(speed_kt: float) -> float:
     return 0.45 + (speed_kt - 100.0) / 200.0 * 0.55
 
 
+def is_taxi_speed_kt(speed_kt: float | None) -> bool:
+    """True when ground speed is known and below LIVE_TRACKING_TAXI_MAX_SPEED_KT (50 kt)."""
+    if speed_kt is None:
+        return False
+    taxi_max_kt, _ = _taxi_settings()
+    return float(speed_kt) < taxi_max_kt
+
+
 def compute_tracking_radius_km(speed_kt: float | None) -> float:
     """Radius = distance the aircraft covers in the preview window,
     clamped to [min, max]. speed_kt is ground speed in knots (the unit
     already used throughout this codebase, e.g. aircraft_min_speed_kt).
 
-    Applies low-speed compression so approach/landing/taxi get a closer
-    map than the raw projected distance alone would suggest.
+    Applies a fixed close-in radius below LIVE_TRACKING_TAXI_MAX_SPEED_KT
+    (default 50 kt → 2 mi), including 0 kt on the ground, then low-speed
+    compression above that band so approach/landing get a closer map than
+    the raw projected distance alone would suggest.
     """
     _, preview_min, min_km, max_km = _settings()
-    if not speed_kt or speed_kt <= 0:
+    taxi_max_kt, taxi_radius_km = _taxi_settings()
+    taxi_km = max(min_km, min(max_km, taxi_radius_km))
+    if speed_kt is None:
         return min_km
     speed_kt_f = float(speed_kt)
+    if speed_kt_f < taxi_max_kt:
+        return taxi_km
     speed_kph = speed_kt_f * KM_PER_NM
     projected_km = speed_kph * (preview_min / 60.0)
     projected_km *= _low_speed_scale(speed_kt_f)


### PR DESCRIPTION
## Summary
- Fix Follow weather overlay lagging behind the basemap (sticky viewport / prefetch alignment).
- Add speed-based Follow map zoom from issue #114 (continuous radius → discrete steps with hysteresis).
- Force 2 mi Follow range for all speeds under 50 kt, including 0 kt on the ground.
- Reset Follow zoom on screen entry; catch up zoom-out on large speed increases; redraw on radius-only changes.