### PR TITLE
Docs: LibreWXR CC BY 4.0 attribution (#117)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,5 +15,6 @@ Indicate if changes were made. Do not imply endorsement by the licensor.
 
 Commercial use is not permitted under this license without a separate written grant.
 
-Third-party components and prior permissions are listed in README.md and remain under
-their respective terms.
+Third-party components and prior permissions are listed in README.md (Credits),
+flightscnr/display/round_touch/PRECIP_ATTRIBUTION.md, and related asset
+ATTRIBUTION.md files, and remain under their respective terms.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A [round **4″ touch display**](https://www.waveshare.com/4inch-dsi-lcd-c.htm?&
 
 ## Features
 
-Live aircraft (and optional marine traffic) on a circular radar, with rich detail screens when you tap. Powered by **FR24**, **[adsb.fi](https://adsb.fi)**, optional local dump1090/readsb, **Tomorrow.io** weather, optional route enrichment, **USGS earthquakes**, and wildfire layers (CAL FIRE / NIFC / NASA FIRMS). Configure everything from the web portal. Full detail: [Features wiki](https://github.com/yashmulgaonkar/FlightScnr_Pi/wiki/Features).
+Live aircraft (and optional marine traffic) on a circular radar, with rich detail screens when you tap. Powered by **FR24**, **[adsb.fi](https://adsb.fi)**, optional local dump1090/readsb, **Tomorrow.io** weather, optional precipitation from **[LibreWXR](https://librewxr.net/)** (RainViewer fallback), optional route enrichment, **USGS earthquakes**, and wildfire layers (CAL FIRE / NIFC / NASA FIRMS). Configure everything from the web portal. Full detail: [Features wiki](https://github.com/yashmulgaonkar/FlightScnr_Pi/wiki/Features).
 
 Current release: **2026.8.21.2** on `main`.
 
@@ -250,6 +250,7 @@ Questions or setup help? Join the **FlightScnrPi Discord**:
 - AIS WebSocket client design adapted from [capsule-radar-ais](https://github.com/socquique/capsule-radar-ais) (MIT).
 - Aircraft photos courtesy of [planespotters.net](https://www.planespotters.net/) contributors (when credited on screen).
 - Vessel photos from [Wikimedia Commons](https://commons.wikimedia.org/) contributors under their respective licenses.
+- Precipitation radar tiles primarily from **[LibreWXR](https://librewxr.net/)** by Joshua Kimsey (public API [`api.librewxr.net`](https://api.librewxr.net/)), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). Fallback: [RainViewer](https://www.rainviewer.com/). See [`flightscnr/display/round_touch/PRECIP_ATTRIBUTION.md`](flightscnr/display/round_touch/PRECIP_ATTRIBUTION.md).
 
 Full asset attributions: [Credits and License](https://github.com/yashmulgaonkar/FlightScnr_Pi/wiki/Credits-and-License).
 

--- a/flightscnr/display/round_touch/PRECIP_ATTRIBUTION.md
+++ b/flightscnr/display/round_touch/PRECIP_ATTRIBUTION.md
@@ -1,0 +1,33 @@
+# Precipitation radar overlay
+
+Live rain/snow tiles for the circular radar map (see `rainviewer_overlay.py`).
+Providers are tried in order:
+
+## LibreWXR (primary)
+
+- Project: [LibreWXR](https://librewxr.net/) by [Joshua Kimsey](https://github.com/JoshuaKimsey)
+- Source: [github.com/JoshuaKimsey/LibreWXR](https://github.com/JoshuaKimsey/LibreWXR)
+- Public API used here: [api.librewxr.net](https://api.librewxr.net/)
+
+**API data** from the public LibreWXR instance is licensed under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+Credit **LibreWXR** when using or redistributing that data.
+
+The LibreWXR *software* is AGPL-3.0-or-later; this project only consumes the
+public HTTP API and does not ship or host LibreWXR itself.
+
+Upstream data-licensing details (including the Italy / Radar-DPC CC-BY-SA
+carve-out) are documented on [librewxr.net](https://librewxr.net/) under
+Data Licensing.
+
+## RainViewer (fallback)
+
+- [RainViewer Weather Maps API](https://www.rainviewer.com/api.html)
+- Used when LibreWXR metadata or tiles are unavailable
+
+Credit **RainViewer** when that path is active.
+
+## On-device credit
+
+When precipitation is shown, the map corner attribution reads `© LibreWXR` or
+`© RainViewer` for the active provider.


### PR DESCRIPTION
## Summary
- Add [`PRECIP_ATTRIBUTION.md`](flightscnr/display/round_touch/PRECIP_ATTRIBUTION.md) for LibreWXR (CC BY 4.0) + RainViewer fallback
- Credit LibreWXR in README Credits and the intro Powered-by line; point NOTICE third-party text at Credits / precip attribution
- Closes #117 (wiki Credits-and-License + Data-Sources updated separately)

## Test plan
- [ ] README Credits names LibreWXR, CC BY 4.0, api.librewxr.net, RainViewer fallback
- [ ] `PRECIP_ATTRIBUTION.md` links librewxr.net / license / Joshua Kimsey
- [ ] Wiki [Credits and License](https://github.com/yashmulgaonkar/FlightScnr_Pi/wiki/Credits-and-License) and [Data Sources](https://github.com/yashmulgaonkar/FlightScnr_Pi/wiki/Data-Sources) match after wiki push

Made with [Cursor](https://cursor.com)