### PR TITLE
Show local ADS-B health and mark local tracks on radar

### DIFF
--- a/flightscnr/display/round_touch/screens/radar.py
+++ b/flightscnr/display/round_touch/screens/radar.py
@@ -940,6 +940,10 @@ def _aircraft_tag_lines(flight):
     alt_color = aircraft.altitude_tag_color(flight.get("vertical_speed"))
 
     lines = []
+    # Local ADS-B marker: * before callsign when dump1090 refreshed this track.
+    if flight.get("local_adsb") and callsign and callsign != "—":
+        if not str(callsign).startswith("*"):
+            callsign = f"* {callsign}"
     raw_lines = [
         (callsign, _overlay_color_for_basemap(theme.GRID), main_font, offsets[0]),
         (plane_type, _overlay_color_for_basemap(theme.TAG_TYPE), sub_font, offsets[1]),

--- a/flightscnr/tests/test_adsb_sources.py
+++ b/flightscnr/tests/test_adsb_sources.py
@@ -72,6 +72,7 @@ class TestDump1090Client(unittest.TestCase):
                 )
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0]["data_source"], "dump1090")
+        self.assertTrue(entries[0].get("local_adsb"))
         self.assertEqual(entries[0]["icao_hex"], "A55DB1")
         self.assertEqual(entries[0]["callsign"].strip(), "N445DB")
 
@@ -198,12 +199,160 @@ class TestDump1090Richness(unittest.TestCase):
             "plane_longitude": -122.301,
             "altitude": 3480,
             "data_source": "dump1090",
+            "local_adsb": True,
             "squawk": "1200",
         }
         with mock.patch.object(aircraft_alert.geo, "distance_km", return_value=0.2):
             out = aircraft_alert.dedupe_flights([cloud, local])
         self.assertEqual(len(out), 1)
         self.assertEqual(out[0]["data_source"], "dump1090")
+        self.assertTrue(out[0].get("local_adsb"))
+
+    def test_dedupe_preserves_local_adsb_when_fr24_wins(self):
+        from utilities import aircraft_alert
+
+        fr24 = {
+            "callsign": "UAL123",
+            "icao_hex": "A12345",
+            "airline": "United",
+            "origin": "SFO",
+            "destination": "EWR",
+            "plane_latitude": 37.80,
+            "plane_longitude": -122.30,
+            "altitude": 10000,
+            "data_source": "fr24_grpc",
+        }
+        local = {
+            "callsign": "UAL123",
+            "icao_hex": "A12345",
+            "plane_latitude": 37.801,
+            "plane_longitude": -122.301,
+            "altitude": 9980,
+            "data_source": "dump1090",
+            "local_adsb": True,
+        }
+        with mock.patch.object(aircraft_alert.geo, "distance_km", return_value=0.2):
+            out = aircraft_alert.dedupe_flights([fr24, local])
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0]["data_source"].startswith("fr24"))
+        self.assertTrue(out[0].get("local_adsb"))
+
+
+class TestLocalAdsbMergeFlag(unittest.TestCase):
+    def test_dump1090_entry_sets_local_adsb(self):
+        from utilities import dump1090_client
+
+        plane = {
+            "hex": "a55db1",
+            "flight": "N445DB ",
+            "r": "N445DB",
+            "t": "GL5T",
+            "lat": 37.80,
+            "lon": -122.30,
+            "alt_baro": 3500,
+            "gs": 220,
+            "track": 90,
+            "seen_pos": 1.0,
+        }
+        entry = dump1090_client._to_entry(
+            plane, home_lat=37.80, home_lon=-122.30, radius_nm=20.0, min_altitude=0
+        )
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["data_source"], "dump1090")
+        self.assertTrue(entry.get("local_adsb"))
+
+    def test_merge_onto_fr24_sets_local_adsb_keeps_source(self):
+        """Simulate overhead merge: dump1090 refreshes FR24 without retagging source."""
+        target = {
+            "callsign": "UAL123",
+            "icao_hex": "A12345",
+            "plane_latitude": 37.80,
+            "plane_longitude": -122.30,
+            "altitude": 10000,
+            "data_source": "fr24_grpc",
+        }
+        entry = {
+            "callsign": "UAL123",
+            "icao_hex": "A12345",
+            "plane_latitude": 37.801,
+            "plane_longitude": -122.301,
+            "altitude": 9980,
+            "heading": 90,
+            "ground_speed": 420,
+            "vertical_speed": 0,
+            "squawk": "1200",
+            "db_flags": 0,
+            "registration": "",
+            "plane": "",
+            "adsb_category": "",
+            "data_source": "dump1090",
+            "local_adsb": True,
+        }
+        from utilities.aircraft_alert import merge_live_fields
+
+        live_fields = (
+            "plane_latitude",
+            "plane_longitude",
+            "altitude",
+            "heading",
+            "ground_speed",
+            "vertical_speed",
+            "squawk",
+            "db_flags",
+            "icao_hex",
+            "registration",
+            "callsign",
+            "plane",
+            "adsb_category",
+        )
+        merge_live_fields(target, entry, live_fields)
+        if entry.get("data_source") == "dump1090":
+            target["local_adsb"] = True
+            src = (target.get("data_source") or "")
+            if src.startswith("adsb") or src == "adsb_fi":
+                target["data_source"] = "dump1090"
+            elif not src:
+                target["data_source"] = "dump1090"
+        self.assertEqual(target["data_source"], "fr24_grpc")
+        self.assertTrue(target.get("local_adsb"))
+        self.assertEqual(target["altitude"], 9980)
+
+    def test_probe_feed_counts_fresh(self):
+        from utilities import dump1090_client
+
+        payload = {
+            "aircraft": [
+                {"hex": "aaa", "lat": 1.0, "lon": 2.0, "seen_pos": 5.0},
+                {"hex": "bbb", "lat": 1.0, "lon": 2.0, "seen_pos": 120.0},
+                {"hex": "ccc", "seen_pos": 1.0},
+            ]
+        }
+        with mock.patch.object(dump1090_client.requests, "get") as get:
+            resp = mock.Mock()
+            resp.raise_for_status = mock.Mock()
+            resp.json.return_value = payload
+            get.return_value = resp
+            out = dump1090_client.probe_feed_status("http://127.0.0.1:8080/data/aircraft.json")
+        self.assertTrue(out["reachable"])
+        self.assertEqual(out["aircraft_total"], 3)
+        self.assertEqual(out["aircraft_fresh"], 1)
+
+    def test_write_and_read_radar_status(self):
+        from utilities import dump1090_client
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = str(Path(tmp) / "dump1090_radar_status.json")
+            with mock.patch.object(dump1090_client, "DATA_DIR", tmp):
+                with mock.patch.object(dump1090_client, "RADAR_STATUS_PATH", path):
+                    dump1090_client.write_radar_status(
+                        enabled=True, ok=True, raw=4, added=1, updated=3
+                    )
+                    data = dump1090_client.read_radar_status()
+        self.assertTrue(data.get("enabled"))
+        self.assertTrue(data.get("ok"))
+        self.assertEqual(data.get("raw"), 4)
+        self.assertEqual(data.get("added"), 1)
+        self.assertEqual(data.get("updated"), 3)
 
 
 if __name__ == "__main__":

--- a/flightscnr/utilities/aircraft_alert.py
+++ b/flightscnr/utilities/aircraft_alert.py
@@ -559,6 +559,8 @@ def dedupe_flights(flights: list[dict], *, threshold_km: float = 1.2) -> list[di
                 flight["callsign"] = duplicate.get("callsign") or flight.get("callsign")
             if not (flight.get("registration") or "").strip():
                 flight["registration"] = duplicate.get("registration") or ""
+            if flight.get("local_adsb") or duplicate.get("local_adsb"):
+                flight["local_adsb"] = True
             _unindex(dup_idx, duplicate)
             kept[dup_idx] = flight
             _index(dup_idx, flight)
@@ -569,6 +571,8 @@ def dedupe_flights(flights: list[dict], *, threshold_km: float = 1.2) -> list[di
                 duplicate["callsign"] = flight.get("callsign") or duplicate.get("callsign")
             if not (duplicate.get("registration") or "").strip():
                 duplicate["registration"] = flight.get("registration") or ""
+            if flight.get("local_adsb") or duplicate.get("local_adsb"):
+                duplicate["local_adsb"] = True
             _index(dup_idx, duplicate)
 
     return kept

--- a/flightscnr/utilities/dump1090_client.py
+++ b/flightscnr/utilities/dump1090_client.py
@@ -15,14 +15,19 @@ and returns flight dicts compatible with overhead/radar display.
 
 from __future__ import annotations
 
+import json
 import logging
 import math
+import os
 import time
 from urllib.parse import urljoin
 
 import requests
 
 logger = logging.getLogger(__name__)
+
+DATA_DIR = os.environ.get("FLIGHTSCNR_DATA_DIR", "/var/lib/flightscnr")
+RADAR_STATUS_PATH = os.path.join(DATA_DIR, "dump1090_radar_status.json")
 
 _CACHE: dict = {
     "entries": [],
@@ -39,6 +44,11 @@ _CONNECT_TIMEOUT_S = 0.5
 _READ_TIMEOUT_S = 2.0
 # Ignore tracks with no fresh position (seconds).
 _MAX_SEEN_POS_S = 60.0
+
+
+def feed_backoff_active() -> bool:
+    """True while skipping network after a failed aircraft.json fetch."""
+    return time.time() < float(_CACHE.get("fail_until") or 0.0)
 
 
 def _parse_alt_ft(plane: dict) -> int:
@@ -171,6 +181,8 @@ def _to_entry(
         "db_flags": 0,
         "adsb_category": adsb_category,
         "data_source": "dump1090",
+        # Radar UI: local receiver refreshed this track (survives FR24 merge).
+        "local_adsb": True,
     }
 
 
@@ -251,3 +263,104 @@ def fetch_aircraft_entries(
         feed_url,
     )
     return list(entries)
+
+
+def write_radar_status(
+    *,
+    enabled: bool,
+    ok: bool | None = None,
+    raw: int = 0,
+    added: int = 0,
+    updated: int = 0,
+    error: str = "",
+    url: str = "",
+) -> None:
+    """Publish last overhead-cycle dump1090 merge stats for the portal."""
+    payload = {
+        "enabled": bool(enabled),
+        "ok": ok,
+        "raw": int(raw),
+        "added": int(added),
+        "updated": int(updated),
+        "error": (error or "")[:240],
+        "url": (url or "")[:240],
+        "ts": time.time(),
+    }
+    try:
+        os.makedirs(DATA_DIR, exist_ok=True)
+        tmp = RADAR_STATUS_PATH + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        os.replace(tmp, RADAR_STATUS_PATH)
+    except OSError as exc:
+        logger.debug("Could not write dump1090 radar status: %s", exc)
+
+
+def read_radar_status() -> dict:
+    """Last overhead dump1090 cycle stats (empty dict if missing/stale file)."""
+    try:
+        with open(RADAR_STATUS_PATH, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+
+
+def probe_feed_status(url: str | None = None) -> dict:
+    """Lightweight health probe of aircraft.json for the portal (web process).
+
+    Returns reachable flag plus total/fresh aircraft counts. Does not apply
+    home-radius filtering — that is overhead's job.
+    """
+    try:
+        from config import DUMP1090_URL
+
+        configured = DUMP1090_URL
+    except ImportError:
+        configured = "http://127.0.0.1:8080/data/aircraft.json"
+    feed_url = _aircraft_json_url(url or configured)
+    out: dict = {
+        "reachable": False,
+        "url": feed_url,
+        "aircraft_total": 0,
+        "aircraft_fresh": 0,
+        "error": "",
+    }
+    try:
+        resp = requests.get(
+            feed_url, timeout=(_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S)
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        out["error"] = str(exc)[:240]
+        return out
+    except ValueError as exc:
+        out["error"] = f"invalid JSON: {exc}"[:240]
+        return out
+
+    aircraft = data.get("aircraft") or data.get("ac") or []
+    if not isinstance(aircraft, list):
+        aircraft = []
+    total = 0
+    fresh = 0
+    for plane in aircraft:
+        if not isinstance(plane, dict):
+            continue
+        total += 1
+        lat = plane.get("lat")
+        lon = plane.get("lon")
+        if not _valid_position(lat, lon):
+            continue
+        try:
+            seen = float(plane.get("seen_pos", plane.get("seen", 0)) or 0)
+        except (TypeError, ValueError):
+            seen = 0.0
+        if seen <= _MAX_SEEN_POS_S:
+            fresh += 1
+    out["reachable"] = True
+    out["aircraft_total"] = total
+    out["aircraft_fresh"] = fresh
+    return out

--- a/flightscnr/utilities/overhead.py
+++ b/flightscnr/utilities/overhead.py
@@ -1301,6 +1301,21 @@ class Overhead:
                     dump_on = DUMP1090_ENABLED
             use_adsb_cloud = adsb_on and location_configured()
             use_dump1090 = dump_on and location_configured()
+            if not use_dump1090:
+                try:
+                    from utilities.dump1090_client import write_radar_status
+
+                    write_radar_status(
+                        enabled=bool(dump_on),
+                        ok=None,
+                        raw=0,
+                        added=0,
+                        updated=0,
+                        error="" if dump_on else "disabled",
+                        url=dump_url or "",
+                    )
+                except Exception:
+                    pass
             if use_adsb_cloud or use_dump1090:
                 from display.round_touch import scale, settings
 
@@ -1317,16 +1332,30 @@ class Overhead:
                         )
                     )
                 dump_entries: list[dict] = []
+                dump_fetch_ok: bool | None = None
+                dump_fetch_error = ""
                 if use_dump1090:
-                    from utilities.dump1090_client import fetch_aircraft_entries as fetch_dump1090
-
-                    dump_entries = fetch_dump1090(
-                        LOCATION_DEFAULT[0],
-                        LOCATION_DEFAULT[1],
-                        search_radius_nm,
-                        MIN_ALTITUDE,
-                        url=dump_url,
+                    from utilities.dump1090_client import (
+                        feed_backoff_active,
+                        fetch_aircraft_entries as fetch_dump1090,
                     )
+
+                    try:
+                        dump_entries = fetch_dump1090(
+                            LOCATION_DEFAULT[0],
+                            LOCATION_DEFAULT[1],
+                            search_radius_nm,
+                            MIN_ALTITUDE,
+                            url=dump_url,
+                        )
+                        dump_fetch_ok = not feed_backoff_active()
+                        if not dump_fetch_ok:
+                            dump_fetch_error = "feed unreachable or invalid (using cache)"
+                    except Exception as exc:
+                        dump_fetch_ok = False
+                        dump_fetch_error = str(exc)[:240]
+                        dump_entries = []
+                        logger.warning("dump1090 fetch raised: %s", exc)
                     stats["dump1090_raw"] = len(dump_entries)
                 else:
                     stats["dump1090_raw"] = 0
@@ -1493,6 +1522,7 @@ class Overhead:
                                         target["registration"] = cs
                             # Prefer local dump1090 tag when it refreshed kinematics.
                             if entry.get("data_source") == "dump1090":
+                                target["local_adsb"] = True
                                 src = (target.get("data_source") or "")
                                 if src.startswith("adsb") or src == "adsb_fi":
                                     target["data_source"] = "dump1090"
@@ -1504,6 +1534,8 @@ class Overhead:
                             )
                             _gil_yield(_i)
                             continue
+                        if entry.get("data_source") == "dump1090":
+                            entry["local_adsb"] = True
                         _maybe_feed_enrich(entry)
                         overhead_data.append(entry)
                         stats[f"{stat_prefix}_added"] = (
@@ -1528,6 +1560,22 @@ class Overhead:
                 # Cloud first, then local dump1090 so local kinematics win on overlap.
                 _merge_position_entries(adsb_entries, stat_prefix="adsb")
                 _merge_position_entries(dump_entries, stat_prefix="dump1090")
+
+                if use_dump1090:
+                    try:
+                        from utilities.dump1090_client import write_radar_status
+
+                        write_radar_status(
+                            enabled=True,
+                            ok=dump_fetch_ok,
+                            raw=int(stats.get("dump1090_raw") or 0),
+                            added=int(stats.get("dump1090_added") or 0),
+                            updated=int(stats.get("dump1090_updated") or 0),
+                            error=dump_fetch_error,
+                            url=dump_url or "",
+                        )
+                    except Exception:
+                        logger.debug("dump1090 radar status write failed", exc_info=True)
 
                 apply_adsb_alert_fields(overhead_data, adsb_entries + dump_entries)
                 _t_dedupe = time()

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -1139,6 +1139,46 @@ def dump1090_portal_status() -> dict:
     return dump1090_settings()
 
 
+@app.get("/dump1090/status.json")
+def dump1090_live_status():
+    """Live local ADS-B feed health + last radar merge counts for the portal."""
+    from secrets_store import dump1090_settings
+    from utilities import dump1090_client
+
+    cfg = dump1090_settings()
+    enabled = bool(cfg.get("DUMP1090_ENABLED"))
+    url = (cfg.get("DUMP1090_URL") or "").strip()
+    out: dict = {
+        "enabled": enabled,
+        "url": url,
+        "reachable": None,
+        "aircraft_total": 0,
+        "aircraft_fresh": 0,
+        "error": "",
+        "radar": {},
+    }
+    radar = dump1090_client.read_radar_status()
+    if radar:
+        out["radar"] = {
+            "ok": radar.get("ok"),
+            "raw": int(radar.get("raw") or 0),
+            "added": int(radar.get("added") or 0),
+            "updated": int(radar.get("updated") or 0),
+            "ts": radar.get("ts"),
+            "error": radar.get("error") or "",
+        }
+    if not enabled:
+        out["error"] = "disabled"
+        return jsonify(out)
+    probe = dump1090_client.probe_feed_status(url or None)
+    out["reachable"] = bool(probe.get("reachable"))
+    out["url"] = probe.get("url") or url
+    out["aircraft_total"] = int(probe.get("aircraft_total") or 0)
+    out["aircraft_fresh"] = int(probe.get("aircraft_fresh") or 0)
+    out["error"] = probe.get("error") or ""
+    return jsonify(out)
+
+
 @app.post("/radar")
 def radar_save():
     from display.round_touch import map_bg, rainviewer_overlay, scale, settings

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -358,7 +358,8 @@
             </div>
             <label for="dump1090_url">aircraft.json URL</label>
             <input id="dump1090_url" type="text" autocomplete="off" placeholder="http://127.0.0.1:8080/data/aircraft.json">
-            <p class="hint">Local receiver feed (dump1090-fa, readsb, or tar1090). Merges with FR24/adsb.fi; local positions win on overlap. Leave off if nothing is listening — connection refused will spam the logs.</p>
+            <p class="hint">Local receiver feed (dump1090-fa, readsb, or tar1090). Merges with FR24/adsb.fi; local positions win on overlap. Leave off if nothing is listening — connection refused will spam the logs. Aircraft heard locally show a <code>*</code> before the callsign on the radar tag.</p>
+            <p id="dump1090-live" class="hint" style="margin-top:.45rem">Status: …</p>
             <button class="btn btn-primary" id="btn-dump1090" style="margin-top:.7rem" type="button">Save local ADS-B</button>
             <div id="dump1090-status" class="status"></div>
         </div>
@@ -1643,9 +1644,59 @@ async function saveDump1090() {
                 : "Local ADS-B disabled."
         );
         await loadAll();
+        await refreshDump1090Live();
     } catch (e) {
         showStatus("dump1090-status", e.message, true);
     }
+}
+
+function formatDump1090Live(data) {
+    if (!data || !data.enabled) {
+        return "Status: disabled";
+    }
+    if (data.reachable === false) {
+        const err = data.error ? ` (${data.error})` : "";
+        return `Status: unreachable${err}`;
+    }
+    if (data.reachable !== true) {
+        return "Status: checking…";
+    }
+    const fresh = Number(data.aircraft_fresh || 0);
+    const total = Number(data.aircraft_total || 0);
+    let line = `Status: reachable — ${fresh} aircraft with fresh position`;
+    if (total > fresh) {
+        line += ` (${total} in feed)`;
+    }
+    const radar = data.radar || {};
+    const added = Number(radar.added || 0);
+    const updated = Number(radar.updated || 0);
+    const raw = Number(radar.raw || 0);
+    if (radar.ts) {
+        line += `. Last radar cycle: ${raw} in range, ${added} new, ${updated} refreshed`;
+        if (radar.ok === false) {
+            line += " (feed error — may be using cache)";
+        }
+    }
+    return line;
+}
+
+let dump1090LiveTimer = null;
+
+async function refreshDump1090Live() {
+    const el = $("dump1090-live");
+    if (!el) return;
+    try {
+        const data = await jsonFetch("/dump1090/status.json");
+        el.textContent = formatDump1090Live(data);
+    } catch (e) {
+        el.textContent = `Status: ${e.message || "unavailable"}`;
+    }
+}
+
+function startDump1090LivePoll() {
+    refreshDump1090Live();
+    if (dump1090LiveTimer) clearInterval(dump1090LiveTimer);
+    dump1090LiveTimer = setInterval(refreshDump1090Live, 5000);
 }
 
 async function saveRouteSourceOrder() {
@@ -3042,6 +3093,7 @@ document.addEventListener("DOMContentLoaded", () => {
     wireRgbGroup("runway");
     loadAll();
     checkUpdates();
+    startDump1090LivePoll();
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Portal Local ADS-B card shows live feed reachability and fresh aircraft count, plus last radar-cycle merge stats
- Radar callsigns get a `*` prefix when local dump1090 refreshed that track (including FR24 overlaps via `local_adsb`)
- Leaves FR24 `data_source` unchanged on merge; env/config behavior otherwise unchanged