### PR TITLE
Fix CARTO basemap “API key required” watermark (#136)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,19 +145,22 @@ TOUCH_USE_FINGER_EVENTS=False
 # Leave unset to use the default buttons/ folder next to config.py.
 #BUTTONS_DIR=/home/pi/my-button-art
 
-# Radar map background (no API key)
+# Radar map background
 #RADAR_MAP_ENABLED=True
 # Default basemap when settings are first created (device Options / portal override):
-#RADAR_MAP_PROVIDER=dark        # CARTO dark_nolabels (default; aliases: carto)
+#RADAR_MAP_PROVIDER=dark        # CARTO dark_nolabels (default; needs CARTO_BASEMAPS_API_KEY)
 #RADAR_MAP_PROVIDER=osm         # OpenStreetMap remapped to a dark radar palette (slow)
 #RADAR_MAP_PROVIDER=stadia_dark # Stadia Alidade Smooth Dark (needs STADIA_MAPS_API_KEY)
 #RADAR_MAP_PROVIDER=toner       # Stamen Toner B&W full style (needs Stadia key)
 #RADAR_MAP_PROVIDER=satellite   # Esri World Imagery (no API key)
 #RADAR_MAP_PROVIDER=streets     # Esri World Street Map — Google-like roadmap (no API key)
 #RADAR_MAP_PROVIDER=black       # solid black (no tiles)
-#RADAR_MAP_PROVIDER=light       # CARTO light_nolabels
-#RADAR_MAP_PROVIDER=voyager     # CARTO Voyager (color street map, no labels)
+#RADAR_MAP_PROVIDER=light       # CARTO light_nolabels (needs CARTO_BASEMAPS_API_KEY)
+#RADAR_MAP_PROVIDER=voyager     # CARTO Voyager (needs CARTO_BASEMAPS_API_KEY)
 #RADAR_MAP_PROVIDER=vfr         # FAA VFR sectional charts (US; public domain ArcGIS tiles)
+# Free CARTO key: https://carto.com/basemaps/apikey/ (dark / light / voyager)
+# Can also be set in the web portal under API Keys (with Use CARTO basemaps toggle).
+#CARTO_BASEMAPS_API_KEY=
 # Free Stadia key: https://client.stadiamaps.com/ (only for stadia_dark / toner)
 # Can also be set in the web portal under API Keys (with Use Stadia Maps toggle).
 #STADIA_MAPS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Radar home, flight detail, **tracked flight** with route map, **Follow / Live** 
 
 ### Map layers
 
-Ten basemap styles: CARTO dark/light/Voyager, OSM dark, **Dark Flat** (solid black), Stadia dark + Toner (free `STADIA_MAPS_API_KEY`), Esri streets/satellite, and free FAA VFR sectionals (US). Optional **tag leaders**, **color by altitude**, precipitation, airport overlays, wildfires, and earthquakes.
+Ten basemap styles: CARTO dark/light/Voyager (free `CARTO_BASEMAPS_API_KEY`), OSM dark, **Dark Flat** (solid black), Stadia dark + Toner (free `STADIA_MAPS_API_KEY`), Esri streets/satellite, and free FAA VFR sectionals (US). Optional **tag leaders**, **color by altitude**, precipitation, airport overlays, wildfires, and earthquakes.
 
 <table>
 <tr>

--- a/flightscnr/display/round_touch/earthquake_overlay.py
+++ b/flightscnr/display/round_touch/earthquake_overlay.py
@@ -681,11 +681,17 @@ def bbox_around(
     return lon - half, lat - half, lon + half, lat + half
 
 
-def _write_map_file(quake_id: str, data: bytes, *, suffix: str = ".png") -> str | None:
+def _write_map_file(
+    quake_id: str,
+    data: bytes,
+    *,
+    suffix: str = ".png",
+    basename: str | None = None,
+) -> str | None:
     if not data or not data.startswith((b"\x89PNG", b"\xff\xd8\xff")):
         logger.warning("Earthquake map: not an image for %s (%d bytes)", quake_id, len(data or b""))
         return None
-    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", quake_id)[:80] or "quake"
+    safe = basename or (re.sub(r"[^a-zA-Z0-9_-]+", "_", quake_id)[:80] or "quake")
     path = os.path.join(_maps_dir(), f"{safe}{suffix}")
     tmp = path + ".tmp"
     try:
@@ -704,7 +710,25 @@ def _cached_map_path(quake_id: str) -> str | None:
         path = os.path.join(_maps_dir(), f"{safe}{suffix}")
         if os.path.isfile(path) and os.path.getsize(path) > 200:
             return path
+    try:
+        from display.round_touch import map_bg
+
+        auth = "k1" if map_bg._carto_api_key() else "k0"
+    except Exception:
+        auth = "k0"
+    for suffix in (".png", ".jpg"):
+        path = os.path.join(_maps_dir(), f"{safe}_carto_{auth}{suffix}")
+        if os.path.isfile(path) and os.path.getsize(path) > 200:
+            return path
     return None
+
+
+def _carto_map_basename(quake_id: str) -> str:
+    from display.round_touch import map_bg
+
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", quake_id)[:80] or "quake"
+    auth = "k1" if map_bg._carto_api_key() else "k0"
+    return f"{safe}_carto_{auth}"
 
 
 def _http_get(
@@ -858,6 +882,8 @@ def _carto_export_map(lat: float, lon: float, quake_id: str) -> str | None:
 
     from PIL import Image
 
+    from display.round_touch import map_bg
+
     zoom = 11
     tx = _lon_to_tile_x(lon, zoom)
     ty = _lat_to_tile_y(lat, zoom)
@@ -867,25 +893,17 @@ def _carto_export_map(lat: float, lon: float, quake_id: str) -> str | None:
             x, y = tx + dx, ty + dy
             if x < 0 or y < 0:
                 continue
-            sub = "abcd"[(x + y) % 4]
-            url = (
-                f"https://{sub}.basemaps.cartocdn.com/rastertiles/voyager/"
-                f"{zoom}/{x}/{y}.png"
-            )
-            try:
-                from display.round_touch import map_bg
-
-                key = map_bg._carto_api_key()
-                if key:
-                    url = f"{url}?key={key}"
-            except Exception:
-                pass
+            url = map_bg._carto_tile_url("rastertiles/voyager", zoom, x, y)
             try:
                 resp = _http_get(url)
                 resp.raise_for_status()
                 tiles[(dx, dy)] = Image.open(BytesIO(resp.content)).convert("RGBA")
             except Exception as exc:
-                logger.debug("CARTO tile %s failed: %s", url.split("?", 1)[0], exc)
+                logger.debug(
+                    "CARTO tile %s failed: %s",
+                    map_bg._tile_url_for_log(url),
+                    exc,
+                )
     if not tiles:
         logger.warning("Earthquake CARTO snapshot got no tiles for %s", quake_id)
         return None
@@ -933,7 +951,12 @@ def _carto_export_map(lat: float, lon: float, quake_id: str) -> str | None:
         logger.debug("Could not overlay epicenter on CARTO map", exc_info=True)
     buf = BytesIO()
     image.save(buf, format="PNG")
-    return _write_map_file(quake_id, buf.getvalue(), suffix=".png")
+    return _write_map_file(
+        quake_id,
+        buf.getvalue(),
+        suffix=".png",
+        basename=_carto_map_basename(quake_id),
+    )
 
 
 def fetch_map_for_quake(quake: dict[str, Any]) -> str | None:

--- a/flightscnr/display/round_touch/earthquake_overlay.py
+++ b/flightscnr/display/round_touch/earthquake_overlay.py
@@ -873,11 +873,19 @@ def _carto_export_map(lat: float, lon: float, quake_id: str) -> str | None:
                 f"{zoom}/{x}/{y}.png"
             )
             try:
+                from display.round_touch import map_bg
+
+                key = map_bg._carto_api_key()
+                if key:
+                    url = f"{url}?key={key}"
+            except Exception:
+                pass
+            try:
                 resp = _http_get(url)
                 resp.raise_for_status()
                 tiles[(dx, dy)] = Image.open(BytesIO(resp.content)).convert("RGBA")
             except Exception as exc:
-                logger.debug("CARTO tile %s failed: %s", url, exc)
+                logger.debug("CARTO tile %s failed: %s", url.split("?", 1)[0], exc)
     if not tiles:
         logger.warning("Earthquake CARTO snapshot got no tiles for %s", quake_id)
         return None

--- a/flightscnr/display/round_touch/map_bg.py
+++ b/flightscnr/display/round_touch/map_bg.py
@@ -76,15 +76,15 @@ MAP_STYLES = (
     "satellite",
 )
 MAP_STYLE_LABELS = {
-    "dark": "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)",
+    "dark": "Dark: Carto",
     "osm": "Dark: OSM",
     "stadia_dark": "Dark: Stadia (needs STADIA_MAPS_API_KEY)",
     "black": "Dark: Flat",
-    "light": "Light: Carto (needs CARTO_BASEMAPS_API_KEY)",
+    "light": "Light: Carto",
     "toner": "Light: Toner (needs STADIA_MAPS_API_KEY)",
     "vfr": "Light: VFR",
     "streets": "Street: Esri",
-    "voyager": "Street: Voyager (needs CARTO_BASEMAPS_API_KEY)",
+    "voyager": "Street: Voyager",
     "satellite": "Satellite: Esri",
 }
 FLAT_BLACK = (0, 0, 0)
@@ -236,6 +236,13 @@ def _carto_tile_url(style_path: str, z: int, x: int, y: int) -> str:
     return url
 
 
+def _carto_cache_auth(style: str) -> int | None:
+    """0 = no key, 1 = keyed; None for non-CARTO styles."""
+    if normalize_map_style(style) not in CARTO_STYLES:
+        return None
+    return 1 if _carto_api_key() else 0
+
+
 def _tile_url_for_log(url: str) -> str:
     if "api_key=" not in url and "key=" not in url:
         return url
@@ -314,17 +321,22 @@ def _cache_key_for_scale(scale_index: int) -> tuple | None:
         return None
     if not location_configured():
         return None
+    style = _resolved_style()
+    carto_auth = _carto_cache_auth(style)
     return (
         round(LOCATION_HOME[0], 5),
         round(LOCATION_HOME[1], 5),
         scale_index,
-        _resolved_style(),
+        style,
+        carto_auth if carto_auth is not None else -1,
     )
 
 
 def _cache_path_for_key(key: tuple) -> str:
     lat, lon, scale_idx, style = key[0], key[1], key[2], key[3]
-    return os.path.join(CACHE_DIR, f"bg_{style}_{lat}_{lon}_{scale_idx}.png")
+    auth = key[4] if len(key) > 4 else -1
+    auth_tag = f"_k{auth}" if auth in (0, 1) else ""
+    return os.path.join(CACHE_DIR, f"bg_{style}{auth_tag}_{lat}_{lon}_{scale_idx}.png")
 
 
 def _manifest_path_for_key(key: tuple) -> str:
@@ -904,6 +916,8 @@ def _save_cache(surface: pygame.Surface, key: tuple):
         "style_version": CACHE_STYLE_VERSION,
         "path": os.path.basename(path),
     }
+    if len(key) > 4 and key[4] in (0, 1):
+        manifest["carto_auth"] = key[4]
     tmp = manifest_path + ".tmp"
     with open(tmp, "w", encoding="utf-8") as fh:
         json.dump(manifest, fh, indent=2)
@@ -926,6 +940,11 @@ def _load_cache(key: tuple) -> pygame.Surface | None:
             if manifest.get("scale_index") != key[2]:
                 return None
             if manifest.get("provider") != key[3]:
+                return None
+            if len(key) > 4 and key[4] in (0, 1):
+                if manifest.get("carto_auth") != key[4]:
+                    return None
+            elif manifest.get("carto_auth") in (0, 1):
                 return None
             if manifest.get("style_version") != CACHE_STYLE_VERSION:
                 return None

--- a/flightscnr/display/round_touch/map_bg.py
+++ b/flightscnr/display/round_touch/map_bg.py
@@ -10,15 +10,15 @@
 """Cached map background for the radar screen.
 
 Styles (settings map_style, fallback RADAR_MAP_PROVIDER):
-  dark — CARTO Dark Matter, no labels (default)
+  dark — CARTO Dark Matter, no labels (default; needs CARTO_BASEMAPS_API_KEY)
   osm — OpenStreetMap tiles remapped to a dark radar palette
   stadia_dark — Stadia Alidade Smooth Dark, lifted for radar (needs STADIA_MAPS_API_KEY)
   toner — Stamen Toner B&W (full style; needs Stadia key)
   satellite — Esri World Imagery (no API key)
   streets — Esri World Street Map, Google-like roadmap (no API key)
   black — solid black circle (no tiles)
-  light — CARTO Positron light, no labels
-  voyager — CARTO Voyager (color street map), no labels
+  light — CARTO Positron light, no labels (needs CARTO_BASEMAPS_API_KEY)
+  voyager — CARTO Voyager (color street map), no labels (needs CARTO_BASEMAPS_API_KEY)
   vfr  — FAA VFR sectional charts (US coverage, public domain)
 """
 
@@ -76,15 +76,15 @@ MAP_STYLES = (
     "satellite",
 )
 MAP_STYLE_LABELS = {
-    "dark": "Dark: Carto",
+    "dark": "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)",
     "osm": "Dark: OSM",
     "stadia_dark": "Dark: Stadia (needs STADIA_MAPS_API_KEY)",
     "black": "Dark: Flat",
-    "light": "Light: Carto",
+    "light": "Light: Carto (needs CARTO_BASEMAPS_API_KEY)",
     "toner": "Light: Toner (needs STADIA_MAPS_API_KEY)",
     "vfr": "Light: VFR",
     "streets": "Street: Esri",
-    "voyager": "Street: Voyager",
+    "voyager": "Street: Voyager (needs CARTO_BASEMAPS_API_KEY)",
     "satellite": "Satellite: Esri",
 }
 FLAT_BLACK = (0, 0, 0)
@@ -92,6 +92,7 @@ FLAT_BLACK = (0, 0, 0)
 OSM_TILE_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
 CARTO_SUBDOMAINS = "abcd"
 CARTO_TILE_URL = "https://{sub}.basemaps.cartocdn.com/{style}/{z}/{x}/{y}.png"
+CARTO_STYLES = frozenset({"dark", "light", "voyager"})
 # ArcGIS MapServer tiles use {z}/{y}/{x} (row/col), not OSM {z}/{x}/{y}.
 VFR_TILE_URL = (
     "https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/"
@@ -118,7 +119,9 @@ CARTO_TILE_WORKERS = 4
 OSM_TILE_WORKERS = 2
 VFR_TILE_WORKERS = 4
 CACHE_TTL_S = 7 * 24 * 3600
-CACHE_STYLE_VERSION = 22  # bump when map tint/placement/styles change
+# Bump when map tint/placement/styles change, or when tile auth changes so
+# watermarked/unauthorized cached PNGs are not kept after an upgrade.
+CACHE_STYLE_VERSION = 23
 
 
 _lock = threading.Lock()
@@ -129,6 +132,7 @@ _surfaces: dict[tuple, pygame.Surface] = {}
 _display_converted: set[tuple] = set()
 _fetch_threads: dict[tuple, threading.Thread] = {}
 _stadia_key_warned = False
+_carto_key_warned = False
 
 
 def normalize_map_style(raw: str | None) -> str:
@@ -198,6 +202,23 @@ def _stadia_api_key() -> str:
     return raw.split("#", 1)[0].strip()
 
 
+def _carto_api_key() -> str:
+    """Free CARTO basemap key (raster tiles watermark without it)."""
+    try:
+        from secrets_store import api_enabled
+
+        if not api_enabled("CARTO_BASEMAPS_API_KEY"):
+            return ""
+    except Exception:
+        pass
+    raw = (
+        os.environ.get("CARTO_BASEMAPS_API_KEY")
+        or os.environ.get("CARTO_API_KEY")
+        or ""
+    )
+    return raw.split("#", 1)[0].strip()
+
+
 def _stadia_tile_url(style_id: str, z: int, x: int, y: int) -> str:
     url = STADIA_TILE_URL.format(style=style_id, z=z, x=x, y=y)
     key = _stadia_api_key()
@@ -206,10 +227,22 @@ def _stadia_tile_url(style_id: str, z: int, x: int, y: int) -> str:
     return url
 
 
+def _carto_tile_url(style_path: str, z: int, x: int, y: int) -> str:
+    sub = CARTO_SUBDOMAINS[(x + y) % len(CARTO_SUBDOMAINS)]
+    url = CARTO_TILE_URL.format(sub=sub, style=style_path, z=z, x=x, y=y)
+    key = _carto_api_key()
+    if key:
+        return f"{url}?key={key}"
+    return url
+
+
 def _tile_url_for_log(url: str) -> str:
-    if "api_key=" not in url:
+    if "api_key=" not in url and "key=" not in url:
         return url
-    return url.split("?", 1)[0] + "?api_key=…"
+    base = url.split("?", 1)[0]
+    if "api_key=" in url:
+        return base + "?api_key=…"
+    return base + "?key=…"
 
 
 def _enabled() -> bool:
@@ -241,8 +274,7 @@ def _tile_url(z: int, x: int, y: int, style: str | None = None) -> str:
     if style == "black":
         return ""
     if style == "dark":
-        sub = CARTO_SUBDOMAINS[(x + y) % len(CARTO_SUBDOMAINS)]
-        return CARTO_TILE_URL.format(sub=sub, style="dark_nolabels", z=z, x=x, y=y)
+        return _carto_tile_url("dark_nolabels", z, x, y)
     if style == "stadia_dark":
         return _stadia_tile_url("alidade_smooth_dark", z, x, y)
     if style == "toner":
@@ -253,13 +285,9 @@ def _tile_url(z: int, x: int, y: int, style: str | None = None) -> str:
     if style == "streets":
         return ESRI_WORLD_STREET_URL.format(z=z, y=y, x=x)
     if style == "light":
-        sub = CARTO_SUBDOMAINS[(x + y) % len(CARTO_SUBDOMAINS)]
-        return CARTO_TILE_URL.format(sub=sub, style="light_nolabels", z=z, x=x, y=y)
+        return _carto_tile_url("light_nolabels", z, x, y)
     if style == "voyager":
-        sub = CARTO_SUBDOMAINS[(x + y) % len(CARTO_SUBDOMAINS)]
-        return CARTO_TILE_URL.format(
-            sub=sub, style="rastertiles/voyager_nolabels", z=z, x=x, y=y
-        )
+        return _carto_tile_url("rastertiles/voyager_nolabels", z, x, y)
     if style == "vfr":
         # FAA ArcGIS: level / row / col
         return VFR_TILE_URL.format(z=z, y=y, x=x)
@@ -404,6 +432,16 @@ def _fetch_tile(
             logger.warning(
                 "Basemap %s needs STADIA_MAPS_API_KEY in /etc/flightscnr.env "
                 "(free key at stadiamaps.com); tiles will 401 without it",
+                style,
+            )
+    if style in CARTO_STYLES and not _carto_api_key():
+        global _carto_key_warned
+        if not _carto_key_warned:
+            _carto_key_warned = True
+            logger.warning(
+                "Basemap %s needs CARTO_BASEMAPS_API_KEY in /etc/flightscnr.env "
+                "or the portal (free key at carto.com/basemaps/apikey); "
+                "tiles show an API-key watermark without it",
                 style,
             )
     for attempt in range(3):

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -98,15 +98,15 @@ MAP_STYLES = (
     "satellite",
 )
 MAP_STYLE_LABELS = {
-    "dark": "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)",
+    "dark": "Dark: Carto",
     "osm": "Dark: OSM",
     "stadia_dark": "Dark: Stadia (needs STADIA_MAPS_API_KEY)",
     "black": "Dark: Flat",
-    "light": "Light: Carto (needs CARTO_BASEMAPS_API_KEY)",
+    "light": "Light: Carto",
     "toner": "Light: Toner (needs STADIA_MAPS_API_KEY)",
     "vfr": "Light: VFR",
     "streets": "Street: Esri",
-    "voyager": "Street: Voyager (needs CARTO_BASEMAPS_API_KEY)",
+    "voyager": "Street: Voyager",
     "satellite": "Satellite: Esri",
 }
 
@@ -1696,7 +1696,7 @@ def map_style() -> str:
 
 
 def map_style_label() -> str:
-    return MAP_STYLE_LABELS.get(map_style(), "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)")
+    return MAP_STYLE_LABELS.get(map_style(), "Dark: Carto")
 
 
 def set_map_style(value: str) -> str:

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -98,15 +98,15 @@ MAP_STYLES = (
     "satellite",
 )
 MAP_STYLE_LABELS = {
-    "dark": "Dark: Carto",
+    "dark": "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)",
     "osm": "Dark: OSM",
     "stadia_dark": "Dark: Stadia (needs STADIA_MAPS_API_KEY)",
     "black": "Dark: Flat",
-    "light": "Light: Carto",
+    "light": "Light: Carto (needs CARTO_BASEMAPS_API_KEY)",
     "toner": "Light: Toner (needs STADIA_MAPS_API_KEY)",
     "vfr": "Light: VFR",
     "streets": "Street: Esri",
-    "voyager": "Street: Voyager",
+    "voyager": "Street: Voyager (needs CARTO_BASEMAPS_API_KEY)",
     "satellite": "Satellite: Esri",
 }
 
@@ -1696,7 +1696,7 @@ def map_style() -> str:
 
 
 def map_style_label() -> str:
-    return MAP_STYLE_LABELS.get(map_style(), "Dark: Carto")
+    return MAP_STYLE_LABELS.get(map_style(), "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)")
 
 
 def set_map_style(value: str) -> str:

--- a/flightscnr/secrets_store.py
+++ b/flightscnr/secrets_store.py
@@ -44,6 +44,7 @@ MANAGED_KEYS = (
     "ADSBEXCHANGE_API_KEY",
     "FIRMS_MAP_KEY",
     "STADIA_MAPS_API_KEY",
+    "CARTO_BASEMAPS_API_KEY",
     "HOME_LAT",
     "HOME_LON",
 )
@@ -72,6 +73,7 @@ TOGGLE_KEYS = (
     "USE_OPENSKY_API",
     "USE_ADSBEXCHANGE_API",
     "USE_STADIA_MAPS",
+    "USE_CARTO_BASEMAPS",
 )
 
 # Non-secret data-source settings stored alongside secrets.json.
@@ -178,6 +180,7 @@ def load_toggles() -> dict[str, bool]:
         "USE_OPENSKY_API": True,
         "USE_ADSBEXCHANGE_API": True,
         "USE_STADIA_MAPS": True,
+        "USE_CARTO_BASEMAPS": True,
     }
     try:
         with open(SECRETS_JSON_PATH, encoding="utf-8") as fh:
@@ -204,6 +207,7 @@ def api_enabled(key_name: str) -> bool:
         "OPENSKY_API_CLIENT_SECRET": "USE_OPENSKY_API",
         "ADSBEXCHANGE_API_KEY": "USE_ADSBEXCHANGE_API",
         "STADIA_MAPS_API_KEY": "USE_STADIA_MAPS",
+        "CARTO_BASEMAPS_API_KEY": "USE_CARTO_BASEMAPS",
     }
     toggle_key = mapping.get(key_name)
     if not toggle_key:
@@ -468,6 +472,7 @@ def save_secrets_from_portal(payload: dict) -> dict[str, str]:
         "adsbexchange_api_key": "ADSBEXCHANGE_API_KEY",
         "firms_map_key": "FIRMS_MAP_KEY",
         "stadia_maps_api_key": "STADIA_MAPS_API_KEY",
+        "carto_basemaps_api_key": "CARTO_BASEMAPS_API_KEY",
     }
     for form_key, env_key in field_map.items():
         if form_key not in payload:
@@ -489,6 +494,7 @@ def save_secrets_from_portal(payload: dict) -> dict[str, str]:
         "use_opensky_api": "USE_OPENSKY_API",
         "use_adsbexchange_api": "USE_ADSBEXCHANGE_API",
         "use_stadia_maps": "USE_STADIA_MAPS",
+        "use_carto_basemaps": "USE_CARTO_BASEMAPS",
     }
     for form_key, key in toggle_map.items():
         if form_key in payload:

--- a/flightscnr/tests/test_earthquake_overlay.py
+++ b/flightscnr/tests/test_earthquake_overlay.py
@@ -247,6 +247,36 @@ class TestEarthquakeOverlay(unittest.TestCase):
         carto.assert_called_once()
         shake.assert_not_called()
 
+    def test_carto_export_map_uses_map_bg_tile_url(self):
+        from display.round_touch import earthquake_overlay, map_bg
+
+        fake_resp = mock.Mock()
+        fake_resp.content = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+            b"\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+            b"\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n"
+            b"-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+        fake_resp.raise_for_status = mock.Mock()
+        with mock.patch.object(
+            map_bg,
+            "_carto_tile_url",
+            side_effect=lambda style, z, x, y: f"https://carto.test/{style}/{z}/{x}/{y}",
+        ) as tile_url:
+            with mock.patch.object(earthquake_overlay, "_http_get", return_value=fake_resp):
+                with mock.patch.object(
+                    earthquake_overlay,
+                    "_write_map_file",
+                    return_value="/tmp/quake_carto.png",
+                ) as write_map:
+                    path = earthquake_overlay._carto_export_map(37.5, -122.2, "nc1")
+        self.assertEqual(path, "/tmp/quake_carto.png")
+        self.assertGreater(tile_url.call_count, 0)
+        for call in tile_url.call_args_list:
+            self.assertEqual(call.args[0], "rastertiles/voyager")
+        write_map.assert_called_once()
+        self.assertIn("_carto_k", write_map.call_args.kwargs.get("basename", ""))
+
     def test_voice_primes_then_plays_new_m3(self):
         from display.round_touch import earthquake_overlay, hourly_chime, settings
 

--- a/flightscnr/tests/test_map_style.py
+++ b/flightscnr/tests/test_map_style.py
@@ -65,18 +65,11 @@ class TestMapStyle(unittest.TestCase):
         self.assertEqual(settings.MAP_STYLE_LABELS["black"], "Dark: Flat")
         self.assertEqual(settings.MAP_STYLE_LABELS["satellite"], "Satellite: Esri")
         self.assertEqual(settings.MAP_STYLE_LABELS["streets"], "Street: Esri")
-        self.assertEqual(
-            settings.MAP_STYLE_LABELS["dark"],
-            "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)",
-        )
-        self.assertEqual(
-            settings.MAP_STYLE_LABELS["light"],
-            "Light: Carto (needs CARTO_BASEMAPS_API_KEY)",
-        )
-        self.assertEqual(
-            settings.MAP_STYLE_LABELS["voyager"],
-            "Street: Voyager (needs CARTO_BASEMAPS_API_KEY)",
-        )
+        self.assertEqual(settings.MAP_STYLE_LABELS["dark"], "Dark: Carto")
+        self.assertEqual(settings.MAP_STYLE_LABELS["light"], "Light: Carto")
+        self.assertEqual(settings.MAP_STYLE_LABELS["voyager"], "Street: Voyager")
+        for label in settings.MAP_STYLE_LABELS.values():
+            self.assertNotIn("CARTO_BASEMAPS_API_KEY", label)
 
     def test_map_style_label_flat_black(self):
         import display.round_touch.settings as settings
@@ -156,6 +149,72 @@ class TestMapStyle(unittest.TestCase):
             redacted,
             "https://a.basemaps.cartocdn.com/dark_nolabels/1/2/3.png?key=…",
         )
+
+    def test_carto_cache_path_includes_auth_suffix(self):
+        from display.round_touch import map_bg
+
+        key_k0 = (37.61966, -122.37204, 0, "dark", 0)
+        key_k1 = (37.61966, -122.37204, 0, "dark", 1)
+        key_osm = (37.61966, -122.37204, 0, "osm", -1)
+
+        path_k0 = map_bg._cache_path_for_key(key_k0)
+        path_k1 = map_bg._cache_path_for_key(key_k1)
+        path_osm = map_bg._cache_path_for_key(key_osm)
+
+        self.assertIn("bg_dark_k0_", path_k0)
+        self.assertIn("bg_dark_k1_", path_k1)
+        self.assertNotIn("_k0_", path_osm)
+        self.assertNotIn("_k1_", path_osm)
+        self.assertNotEqual(path_k0, path_k1)
+
+    def test_cache_key_for_scale_tracks_carto_auth(self):
+        from display.round_touch import map_bg
+
+        with patch("config.location_configured", return_value=True), patch(
+            "config.LOCATION_HOME", [37.62, -122.37]
+        ), patch.object(map_bg, "_resolved_style", return_value="dark"):
+            with patch.object(map_bg, "_carto_api_key", return_value=""):
+                key_no = map_bg._cache_key_for_scale(0)
+            with patch.object(map_bg, "_carto_api_key", return_value="secret"):
+                key_yes = map_bg._cache_key_for_scale(0)
+
+        self.assertEqual(key_no[-1], 0)
+        self.assertEqual(key_yes[-1], 1)
+        self.assertNotEqual(key_no, key_yes)
+
+    def test_load_cache_rejects_mismatched_carto_auth(self):
+        import json
+        import tempfile
+
+        import pygame
+
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+        pygame.init()
+        from display.round_touch import map_bg
+
+        key_k1 = (37.61966, -122.37204, 0, "dark", 1)
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(map_bg, "CACHE_DIR", tmp):
+                path = map_bg._cache_path_for_key(key_k1)
+                manifest_path = map_bg._manifest_path_for_key(key_k1)
+                os.makedirs(tmp, exist_ok=True)
+                surf = pygame.Surface((8, 8))
+                surf.fill((0, 0, 0))
+                pygame.image.save(surf, path)
+                with open(manifest_path, "w", encoding="utf-8") as fh:
+                    json.dump(
+                        {
+                            "home_lat": key_k1[0],
+                            "home_lon": key_k1[1],
+                            "scale_index": key_k1[2],
+                            "provider": key_k1[3],
+                            "carto_auth": 0,
+                            "style_version": map_bg.CACHE_STYLE_VERSION,
+                            "fetched_at": 1_700_000_000,
+                        },
+                        fh,
+                    )
+                self.assertIsNone(map_bg._load_cache(key_k1))
 
     def test_candidate_attribution(self):
         from display.round_touch import map_bg

--- a/flightscnr/tests/test_map_style.py
+++ b/flightscnr/tests/test_map_style.py
@@ -65,9 +65,18 @@ class TestMapStyle(unittest.TestCase):
         self.assertEqual(settings.MAP_STYLE_LABELS["black"], "Dark: Flat")
         self.assertEqual(settings.MAP_STYLE_LABELS["satellite"], "Satellite: Esri")
         self.assertEqual(settings.MAP_STYLE_LABELS["streets"], "Street: Esri")
-        self.assertEqual(settings.MAP_STYLE_LABELS["dark"], "Dark: Carto")
-        self.assertEqual(settings.MAP_STYLE_LABELS["light"], "Light: Carto")
-        self.assertEqual(settings.MAP_STYLE_LABELS["voyager"], "Street: Voyager")
+        self.assertEqual(
+            settings.MAP_STYLE_LABELS["dark"],
+            "Dark: Carto (needs CARTO_BASEMAPS_API_KEY)",
+        )
+        self.assertEqual(
+            settings.MAP_STYLE_LABELS["light"],
+            "Light: Carto (needs CARTO_BASEMAPS_API_KEY)",
+        )
+        self.assertEqual(
+            settings.MAP_STYLE_LABELS["voyager"],
+            "Street: Voyager (needs CARTO_BASEMAPS_API_KEY)",
+        )
 
     def test_map_style_label_flat_black(self):
         import display.round_touch.settings as settings
@@ -106,6 +115,20 @@ class TestMapStyle(unittest.TestCase):
 
         dark = map_bg._tile_url(11, 327, 791, "dark")
         self.assertIn("basemaps.cartocdn.com/dark_nolabels/11/327/791.png", dark)
+        self.assertNotIn("key=", dark)
+
+        with patch.dict(os.environ, {"CARTO_BASEMAPS_API_KEY": "carto-secret"}, clear=False):
+            dark_keyed = map_bg._tile_url(11, 327, 791, "dark")
+            light_keyed = map_bg._tile_url(11, 327, 791, "light")
+            voyager_keyed = map_bg._tile_url(11, 327, 791, "voyager")
+        self.assertIn("key=carto-secret", dark_keyed)
+        self.assertIn("basemaps.cartocdn.com/light_nolabels/11/327/791.png", light_keyed)
+        self.assertIn("key=carto-secret", light_keyed)
+        self.assertIn(
+            "basemaps.cartocdn.com/rastertiles/voyager_nolabels/11/327/791.png",
+            voyager_keyed,
+        )
+        self.assertIn("key=carto-secret", voyager_keyed)
 
         sat = map_bg._tile_url(12, 655, 1583, "satellite")
         self.assertIn("World_Imagery/MapServer/tile/12/1583/655", sat)
@@ -122,6 +145,17 @@ class TestMapStyle(unittest.TestCase):
 
         osm = map_bg._tile_url(9, 81, 197, "osm")
         self.assertEqual(osm, "https://tile.openstreetmap.org/9/81/197.png")
+
+    def test_tile_url_for_log_redacts_carto_key(self):
+        from display.round_touch import map_bg
+
+        redacted = map_bg._tile_url_for_log(
+            "https://a.basemaps.cartocdn.com/dark_nolabels/1/2/3.png?key=secret"
+        )
+        self.assertEqual(
+            redacted,
+            "https://a.basemaps.cartocdn.com/dark_nolabels/1/2/3.png?key=…",
+        )
 
     def test_candidate_attribution(self):
         from display.round_touch import map_bg

--- a/flightscnr/tests/test_portal_rim_stadia_follow.py
+++ b/flightscnr/tests/test_portal_rim_stadia_follow.py
@@ -102,5 +102,37 @@ class TestStadiaToggle(unittest.TestCase):
             self.assertEqual(map_bg._stadia_api_key(), "secret")
 
 
+class TestCartoToggle(unittest.TestCase):
+    def test_api_enabled_maps_carto_toggle(self):
+        from secrets_store import api_enabled
+
+        with mock.patch(
+            "secrets_store.load_toggles",
+            return_value={"USE_CARTO_BASEMAPS": False},
+        ):
+            self.assertFalse(api_enabled("CARTO_BASEMAPS_API_KEY"))
+        with mock.patch(
+            "secrets_store.load_toggles",
+            return_value={"USE_CARTO_BASEMAPS": True},
+        ):
+            self.assertTrue(api_enabled("CARTO_BASEMAPS_API_KEY"))
+
+    def test_carto_key_empty_when_toggle_off(self):
+        from display.round_touch import map_bg
+
+        with mock.patch(
+            "secrets_store.api_enabled", return_value=False
+        ), mock.patch.dict(
+            os.environ, {"CARTO_BASEMAPS_API_KEY": "carto-secret"}, clear=False
+        ):
+            self.assertEqual(map_bg._carto_api_key(), "")
+        with mock.patch(
+            "secrets_store.api_enabled", return_value=True
+        ), mock.patch.dict(
+            os.environ, {"CARTO_BASEMAPS_API_KEY": "carto-secret"}, clear=False
+        ):
+            self.assertEqual(map_bg._carto_api_key(), "carto-secret")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -202,15 +202,15 @@
             <p class="hint">Sets RUNWAY_DARKMAP — runway centerline color on the dark basemap (skipped on VFR).</p>
             <label for="map_style">Map style</label>
             <select id="map_style">
-                <option value="dark">Dark: Carto (needs CARTO_BASEMAPS_API_KEY)</option>
+                <option value="dark">Dark: Carto</option>
                 <option value="osm">Dark: OSM</option>
                 <option value="stadia_dark">Dark: Stadia (needs STADIA_MAPS_API_KEY)</option>
                 <option value="black">Dark: Flat</option>
-                <option value="light">Light: Carto (needs CARTO_BASEMAPS_API_KEY)</option>
+                <option value="light">Light: Carto</option>
                 <option value="toner">Light: Toner (needs STADIA_MAPS_API_KEY)</option>
                 <option value="vfr">Light: VFR (FAA)</option>
                 <option value="streets">Street: Esri</option>
-                <option value="voyager">Street: Voyager (CARTO, needs CARTO_BASEMAPS_API_KEY)</option>
+                <option value="voyager">Street: Voyager (CARTO)</option>
                 <option value="satellite">Satellite: Esri</option>
             </select>
             <p class="hint">Dark/Light/Voyager Carto need a free CARTO_BASEMAPS_API_KEY. Dark: Stadia and Light: Toner need a free STADIA_MAPS_API_KEY. OSM, Esri, Flat, and VFR need no key. VFR sectionals are public-domain FAA charts (US coverage).</p>

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -202,18 +202,18 @@
             <p class="hint">Sets RUNWAY_DARKMAP — runway centerline color on the dark basemap (skipped on VFR).</p>
             <label for="map_style">Map style</label>
             <select id="map_style">
-                <option value="dark">Dark: Carto</option>
+                <option value="dark">Dark: Carto (needs CARTO_BASEMAPS_API_KEY)</option>
                 <option value="osm">Dark: OSM</option>
                 <option value="stadia_dark">Dark: Stadia (needs STADIA_MAPS_API_KEY)</option>
                 <option value="black">Dark: Flat</option>
-                <option value="light">Light: Carto</option>
+                <option value="light">Light: Carto (needs CARTO_BASEMAPS_API_KEY)</option>
                 <option value="toner">Light: Toner (needs STADIA_MAPS_API_KEY)</option>
                 <option value="vfr">Light: VFR (FAA)</option>
                 <option value="streets">Street: Esri</option>
-                <option value="voyager">Street: Voyager (CARTO)</option>
+                <option value="voyager">Street: Voyager (CARTO, needs CARTO_BASEMAPS_API_KEY)</option>
                 <option value="satellite">Satellite: Esri</option>
             </select>
-            <p class="hint">Dark/Light/Street/Satellite Carto, OSM, Esri, Voyager, Flat, and VFR need no key. Dark: Stadia and Light: Toner need a free STADIA_MAPS_API_KEY. VFR sectionals are public-domain FAA charts (US coverage).</p>
+            <p class="hint">Dark/Light/Voyager Carto need a free CARTO_BASEMAPS_API_KEY. Dark: Stadia and Light: Toner need a free STADIA_MAPS_API_KEY. OSM, Esri, Flat, and VFR need no key. VFR sectionals are public-domain FAA charts (US coverage).</p>
             <label for="vfr_opacity">VFR map opacity <span id="vfr_opacity_label">45%</span></label>
             <input id="vfr_opacity" type="range" min="15" max="100" step="1" value="45">
             <p class="hint">How strong the VFR chart appears under traffic (lower = paler). Applies when map style is VFR.</p>
@@ -740,6 +740,14 @@
             <p class="hint" id="firms-hint"></p>
             <p class="hint">Free key from <a href="https://firms.modaps.eosdis.nasa.gov/api/map_key/" target="_blank" rel="noopener">FIRMS map key</a>. Used for satellite hotspots when the radar is outside the USA and Canada. In California: CAL FIRE; elsewhere in USA/Canada: NIFC WFIGS (no key).</p>
             <div class="chk">
+                <label for="use-carto-basemaps">Use CARTO basemaps</label>
+                <span class="switch"><input id="use-carto-basemaps" type="checkbox" checked><span class="track"></span></span>
+            </div>
+            <label for="carto-key">CARTO basemaps API key</label>
+            <input type="password" id="carto-key" placeholder="API key" autocomplete="off">
+            <p class="hint" id="carto-hint"></p>
+            <p class="hint">Free key from <a href="https://carto.com/basemaps/apikey/" target="_blank" rel="noopener">CARTO basemaps</a> (no CARTO account required). Required for Dark: Carto, Light: Carto, and Street: Voyager — without it tiles show an “API key required” watermark.</p>
+            <div class="chk">
                 <label for="use-stadia-maps">Use Stadia Maps</label>
                 <span class="switch"><input id="use-stadia-maps" type="checkbox" checked><span class="track"></span></span>
             </div>
@@ -945,6 +953,7 @@ function applyKeyHints(keys) {
         ADSBEXCHANGE_API_KEY: "adsbexchange-hint",
         FIRMS_MAP_KEY: "firms-hint",
         STADIA_MAPS_API_KEY: "stadia-hint",
+        CARTO_BASEMAPS_API_KEY: "carto-hint",
     };
     Object.entries(map).forEach(([key, id]) => {
         const el = $(id);
@@ -1378,6 +1387,9 @@ async function loadAll() {
         }
         if ($("use-stadia-maps")) {
             $("use-stadia-maps").checked = toggles.USE_STADIA_MAPS !== false;
+        }
+        if ($("use-carto-basemaps")) {
+            $("use-carto-basemaps").checked = toggles.USE_CARTO_BASEMAPS !== false;
         }
         const rso = keys.route_source_order || {};
         if ($("route_source_order")) {
@@ -2134,6 +2146,7 @@ async function saveApiKeys(restart) {
                 adsbexchange_api_key: $("adsbexchange-key") ? $("adsbexchange-key").value : "",
                 firms_map_key: $("firms-key") ? $("firms-key").value : "",
                 stadia_maps_api_key: $("stadia-key") ? $("stadia-key").value : "",
+                carto_basemaps_api_key: $("carto-key") ? $("carto-key").value : "",
                 use_fr24_api: $("use-fr24-api").checked,
                 use_tomorrow_weather: $("use-tomorrow-weather").checked,
                 use_airlabs_api: $("use-airlabs-api").checked,
@@ -2142,6 +2155,7 @@ async function saveApiKeys(restart) {
                 use_opensky_api: $("use-opensky-api") ? $("use-opensky-api").checked : true,
                 use_adsbexchange_api: $("use-adsbexchange-api") ? $("use-adsbexchange-api").checked : false,
                 use_stadia_maps: $("use-stadia-maps") ? $("use-stadia-maps").checked : true,
+                use_carto_basemaps: $("use-carto-basemaps") ? $("use-carto-basemaps").checked : true,
                 restart: !!restart,
             }),
         });
@@ -2155,6 +2169,7 @@ async function saveApiKeys(restart) {
         if ($("adsbexchange-key")) $("adsbexchange-key").value = "";
         if ($("firms-key")) $("firms-key").value = "";
         if ($("stadia-key")) $("stadia-key").value = "";
+        if ($("carto-key")) $("carto-key").value = "";
         if (data.keys) applyKeyHints(data.keys);
         showStatus("api-keys-status", data.message || "API keys saved.");
     } catch (e) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CARTO recently started watermarking unauthenticated **raster** basemap tiles with “API KEY REQUIRED / carto.com/basemapapikey”. FlightScnr’s default Dark: Carto (and Light / Voyager) styles hit `basemaps.cartocdn.com` with no key, which is why devices on `main` show the overlay from [#136](https://github.com/yashmulgaonkar/FlightScnr_Pi/issues/136).

This change mirrors the existing Stadia key flow:

- New `CARTO_BASEMAPS_API_KEY` (alias `CARTO_API_KEY`) + `USE_CARTO_BASEMAPS` toggle
- Portal API Keys field + Radar map-style hints updated
- Tile URLs append `?key=…` for dark / light / voyager
- Earthquake CARTO snapshot path uses the same key
- Cache style version bumped so watermarked on-disk tiles are discarded after upgrade

Free keys (no CARTO account): https://carto.com/basemaps/apikey/

## Test plan

- [x] `unittest` for map tile URL key append + portal toggle (`test_map_style`, `test_portal_rim_stadia_follow`)
- [ ] On device: set key in portal → Save & restart → Dark/Light/Voyager show clean tiles (no watermark)
- [ ] Confirm OSM / Esri / Flat / VFR still work without a CARTO key

Fixes #136

---

License: CC BY-NC-SA 4.0 — commercial use of this project requires separate permission.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a041b3-edf9-701a-8959-22febe60df03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a041b3-edf9-701a-8959-22febe60df03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

