### PR TITLE
Fix: "Don't show again" still showed the boot disclaimer every boot

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -464,17 +464,21 @@ class RoundTouchDisplay:
         return max(0, int(math.ceil(self._disclaimer_deadline - time.time())))
 
     def _arm_disclaimer_countdown_if_needed(self) -> None:
-        """Start the auto-continue deadline once the disclaimer is visible after splash."""
+        """Skip the gate outright for a remembered Accept, once the splash ends.
+
+        "Don't show again" previously only armed an auto-continue countdown,
+        so the disclaimer still appeared every boot for several seconds. A
+        remembered acceptance now continues immediately; re-showing the
+        disclaimer is done by clearing acceptance from the web portal.
+        """
         if self._disclaimer_countdown_armed:
             return
         if time.time() < self._boot_until:
             return
-        # Arm from the boot-time remember state; checkbox toggles during the
-        # countdown do not cancel or restart the timer.
         if not self._disclaimer_remembered_boot:
             return
         self._disclaimer_countdown_armed = True
-        self._disclaimer_deadline = time.time() + DISCLAIMER_AUTO_CONTINUE_S
+        self._accept_safety_disclaimer(from_auto=True)
 
     def _toggle_disclaimer_remember(self) -> None:
         """Touch-only checkbox; during countdown, value is saved when the timer ends."""

--- a/flightscnr/tests/test_disclaimer_acceptance.py
+++ b/flightscnr/tests/test_disclaimer_acceptance.py
@@ -140,20 +140,35 @@ class TestDisclaimerBootFlow(unittest.TestCase):
         d._start_update_check_thread = lambda: None
         return d
 
-    def test_arms_countdown_only_when_remembered_and_visible(self):
+    def test_remembered_boot_skips_gate_after_splash(self):
+        """"Don't show again" means the gate never waits: accept immediately."""
         d = self._bare()
         d._disclaimer_remembered_boot = True
         d._disclaimer_remember_checked = True
+        accepted: list[bool] = []
+        d._accept_safety_disclaimer = lambda **kw: accepted.append(
+            kw.get("from_auto", False)
+        )
+        # Splash still up — do not accept yet.
         d._boot_until = time.time() + 30
         d._arm_disclaimer_countdown_if_needed()
+        self.assertEqual(accepted, [])
         self.assertIsNone(d._disclaimer_deadline)
+        # Splash done — skip the gate outright, no countdown.
         d._boot_until = 0.0
         d._arm_disclaimer_countdown_if_needed()
-        self.assertIsNotNone(d._disclaimer_deadline)
-        remaining = d._disclaimer_countdown_remaining()
-        self.assertIsNotNone(remaining)
-        self.assertLessEqual(remaining, app_mod.DISCLAIMER_AUTO_CONTINUE_S)
-        self.assertGreaterEqual(remaining, app_mod.DISCLAIMER_AUTO_CONTINUE_S - 1)
+        self.assertEqual(accepted, [True])
+        self.assertIsNone(d._disclaimer_deadline)
+
+    def test_not_remembered_boot_never_auto_accepts(self):
+        d = self._bare()
+        d._disclaimer_remembered_boot = False
+        accepted: list[bool] = []
+        d._accept_safety_disclaimer = lambda **kw: accepted.append(True)
+        d._boot_until = 0.0
+        d._arm_disclaimer_countdown_if_needed()
+        self.assertEqual(accepted, [])
+        self.assertIsNone(d._disclaimer_deadline)
 
     def test_checkbox_toggle_during_countdown_keeps_timer_and_saves_at_expiry(self):
         d = self._bare()


### PR DESCRIPTION
Checking **Don't show again** on the safety disclaimer didn't stop it from showing: a remembered acceptance only armed the 8-second auto-continue countdown, so the screen still appeared on every boot and dismissed itself.

With this change, a remembered acceptance continues past the gate as soon as the boot splash ends — the disclaimer isn't shown at all. First boot (or after the disclaimer version bumps, or after acceptance is cleared) still requires an explicit on-device Accept, unchanged.

Notes for review:
- Users can re-show the disclaimer by clearing acceptance in the web portal (existing flow); the old "uncheck during the countdown" path is gone along with the countdown.
- The countdown deadline/drawing machinery is left in place but no longer armed — happy to strip it in this PR or a follow-up if you'd rather.
- Tests updated: remembered boot skips immediately after splash; non-remembered boot never auto-accepts; existing accept/persist/keyboard tests unchanged and passing (verified on a Pi 4).