### PR TITLE
Round-number range scales per display unit

### DIFF
--- a/flightscnr/display/round_touch/scale.py
+++ b/flightscnr/display/round_touch/scale.py
@@ -10,21 +10,60 @@
 """Radar range scale bands (FlightScnr radar_scale.h)."""
 
 STATUTE_MILE_KM = 1.609344
+NM_KM = 1.852
 LABEL_TO_COVERAGE = 4.0 / 3.0
+
+# Round-number band values per display unit — same 8 steps each, so a saved
+# scale_index survives a unit switch at roughly the same zoom. Ring pixel
+# radii never change; only what the rings mean (and fetch radii) shifts.
+UNIT_BANDS = {
+    "mi": (2, 3, 5, 8, 10, 20, 30, 50),
+    "km": (3, 5, 8, 12, 15, 30, 50, 80),
+    "nm": (2, 3, 5, 7, 10, 15, 25, 40),
+}
+_UNIT_KM = {"mi": STATUTE_MILE_KM, "km": 1.0, "nm": NM_KM}
+
 
 def _band(miles: float) -> dict:
     label_km = miles * STATUTE_MILE_KM
     return {"label_km": label_km, "coverage_km": label_km * LABEL_TO_COVERAGE}
 
 
-SCALE_BANDS = [_band(m) for m in (2, 3, 5, 8, 10, 20, 30, 50)]
-PRESET_STATUTE_MILES = tuple(m for m in (2, 3, 5, 8, 10, 20, 30, 50))
+SCALE_BANDS = [_band(m) for m in UNIT_BANDS["mi"]]
+PRESET_STATUTE_MILES = UNIT_BANDS["mi"]
 
 _active_index = 1
 
 
+def _resolve_units(units: str | None) -> str:
+    if units is None:
+        try:
+            from display.round_touch import settings
+
+            units = settings.distance_units()
+        except Exception:
+            units = "mi"
+    units = (units or "mi").lower()
+    return units if units in UNIT_BANDS else "mi"
+
+
+def bands(units: str | None = None) -> list[dict]:
+    """Band dicts for a display unit (defaults to the active setting)."""
+    u = _resolve_units(units)
+    factor = _UNIT_KM[u]
+    out = []
+    for v in UNIT_BANDS[u]:
+        label_km = v * factor
+        out.append({
+            "value": v,
+            "label_km": label_km,
+            "coverage_km": label_km * LABEL_TO_COVERAGE,
+        })
+    return out
+
+
 def active_band():
-    return SCALE_BANDS[_active_index]
+    return bands()[_active_index]
 
 
 def active_index():
@@ -48,7 +87,7 @@ def search_radius_nm(index: int | None = None) -> float:
         idx = active_index()
     else:
         idx = max(0, min(int(index), len(SCALE_BANDS) - 1))
-    band = SCALE_BANDS[idx]
+    band = bands()[idx]
     try:
         from display.round_touch import theme
 
@@ -84,8 +123,9 @@ def format_active_tag(units: str = "km") -> str:
 
 
 def format_band_tag(index: int, units: str = "km") -> str:
+    u = _resolve_units(units)
     idx = max(0, min(int(index), len(SCALE_BANDS) - 1))
-    return format_scale_tag(SCALE_BANDS[idx]["label_km"], units)
+    return f"{bands(u)[idx]['value']}{u}"
 
 
 def value_to_km(value: float, units: str = "mi") -> float:
@@ -99,11 +139,12 @@ def value_to_km(value: float, units: str = "mi") -> float:
 
 def index_for_value(value: float, units: str = "mi") -> int:
     """Snap to the nearest scale band for a distance in the given units."""
-    target_km = value_to_km(float(value), units)
+    u = _resolve_units(units)
+    target = float(value)
     best_idx = 0
     best_diff = float("inf")
-    for i, band in enumerate(SCALE_BANDS):
-        diff = abs(band["label_km"] - target_km)
+    for i, band in enumerate(bands(u)):
+        diff = abs(band["value"] - target)
         if diff < best_diff:
             best_diff = diff
             best_idx = i
@@ -111,15 +152,10 @@ def index_for_value(value: float, units: str = "mi") -> int:
 
 
 def display_value_for_index(index: int, units: str = "mi") -> float:
-    """Numeric range for portal display in the given units."""
+    """Numeric range for portal display in the given units (always round)."""
+    u = _resolve_units(units)
     idx = max(0, min(int(index), len(SCALE_BANDS) - 1))
-    label_km = SCALE_BANDS[idx]["label_km"]
-    units = (units or "km").lower()
-    if units == "mi":
-        return label_km / STATUTE_MILE_KM
-    if units == "nm":
-        return label_km * NM_PER_KM
-    return label_km
+    return bands(u)[idx]["value"]
 
 
 def format_display_value(index: int, units: str = "mi") -> str:

--- a/flightscnr/tests/test_scale.py
+++ b/flightscnr/tests/test_scale.py
@@ -29,5 +29,57 @@ class TestScaleSnapping(unittest.TestCase):
         self.assertEqual(scale.index_for_value(80, "km"), 7)
 
 
+class TestRoundUnitBands(unittest.TestCase):
+    """Each unit gets its own round-number band table (same 8 steps)."""
+
+    def test_tables_share_length(self):
+        for units in ("mi", "km", "nm"):
+            self.assertEqual(len(scale.bands(units)), len(scale.SCALE_BANDS))
+
+    def test_display_values_are_round(self):
+        self.assertEqual(
+            [scale.display_value_for_index(i, "km") for i in range(8)],
+            [3, 5, 8, 12, 15, 30, 50, 80])
+        self.assertEqual(
+            [scale.display_value_for_index(i, "nm") for i in range(8)],
+            [2, 3, 5, 7, 10, 15, 25, 40])
+        self.assertEqual(
+            [scale.display_value_for_index(i, "mi") for i in range(8)],
+            [2, 3, 5, 8, 10, 20, 30, 50])
+
+    def test_band_tags_are_round_in_unit(self):
+        self.assertEqual(scale.format_band_tag(4, "km"), "15km")
+        self.assertEqual(scale.format_band_tag(4, "nm"), "10nm")
+        self.assertEqual(scale.format_band_tag(4, "mi"), "10mi")
+        self.assertEqual(scale.format_band_tag(7, "nm"), "40nm")
+
+    def test_index_snaps_within_unit_table(self):
+        self.assertEqual(scale.index_for_value(15, "km"), 4)
+        self.assertEqual(scale.index_for_value(10, "nm"), 4)
+        self.assertEqual(scale.index_for_value(14, "nm"), 5)
+
+    def test_active_band_follows_display_unit(self):
+        from unittest import mock
+
+        from display.round_touch import settings
+
+        scale.select(4)
+        with mock.patch.object(settings, "distance_units", return_value="nm"):
+            self.assertAlmostEqual(
+                scale.active_band()["label_km"], 10 * 1.852, places=3)
+        with mock.patch.object(settings, "distance_units", return_value="km"):
+            self.assertAlmostEqual(scale.active_band()["label_km"], 15.0, places=3)
+
+    def test_outer_ring_label_is_exact(self):
+        from unittest import mock
+
+        from display.round_touch import settings
+
+        scale.select(4)
+        with mock.patch.object(settings, "distance_units", return_value="nm"):
+            outer_km = scale.active_band()["label_km"]
+            self.assertEqual(scale.format_scale_tag(outer_km, "nm"), "10nm")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -1121,6 +1121,7 @@ def radar_json():
             "scale_index": idx,
             "range_value": scale.format_display_value(idx, units),
             "range_presets_mi": list(scale.PRESET_STATUTE_MILES),
+            "range_presets": {u: list(v) for u, v in scale.UNIT_BANDS.items()},
             "min_height_ft": settings.min_height_ft(),
             "max_height_ft": settings.max_height_ft(),
             "theme_rgb": list(settings.theme_rgb()),
@@ -1211,11 +1212,26 @@ def radar_save():
     from display.round_touch import map_bg, rainviewer_overlay, scale, settings
 
     data = request.get_json(silent=True) or {}
+    units_before = settings.distance_units()
     if "unit_preset" in data:
         settings.set_unit_preset(str(data.get("unit_preset") or ""))
     elif "distance_units" in data:
         settings.set_distance_units(data.get("distance_units"))
     units = settings.distance_units()
+    if units != units_before:
+        # Round-number bands are per-unit, so a unit switch moves the real
+        # coverage a few percent — refetch the basemap and overlays.
+        map_bg.request_background()
+        rainviewer_overlay.request_overlay()
+        try:
+            from display.round_touch import earthquake_overlay, wildfire_overlay
+
+            wildfire_overlay.invalidate()
+            wildfire_overlay.request_refresh(force=True)
+            earthquake_overlay.invalidate()
+            earthquake_overlay.request_refresh(force=True)
+        except Exception:
+            pass
     if "range_value" in data:
         raw = str(data.get("range_value", "")).strip()
         try:

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -1013,7 +1013,13 @@ function formatRangeUnit(index, units) {
     return value.toFixed(1);
 }
 
+let rangePresetUnits = null;
+
 function formatRangeOptionLabel(index) {
+    if (rangePresetUnits) {
+        const mi = rangePresetUnits.mi[index], km = rangePresetUnits.km[index], nm = rangePresetUnits.nm[index];
+        return `${mi}mi / ${km}km / ${nm}nm`;
+    }
     return `${formatRangeUnit(index, "mi")}mi / ${formatRangeUnit(index, "km")}km / ${formatRangeUnit(index, "nm")}nm`;
 }
 
@@ -1254,6 +1260,7 @@ async function loadAll() {
         const r = await jsonFetch("/radar/json");
         currentScaleIndex = Number(r.scale_index ?? 1);
         $("dist_units").value = r.unit_preset || legacyUnitPreset(r.distance_units) || "km_kph";
+        if (r.range_presets) rangePresetUnits = r.range_presets;
         populateRangeSelect(r.range_presets_mi);
         syncMinSpeedUnitLabels();
         $("min_height").value = String(r.min_height_ft ?? 1000);


### PR DESCRIPTION
Range steps were fixed at 2/3/5/8/10/20/30/50 statute miles and only converted for display, so km and nm users saw values like 16km or 8.7nm (and 11.6nm at 20mi... not exactly chart-friendly).

## What it does

- Each display unit gets its own 8-step band table of round numbers: **mi** 2/3/5/8/10/20/30/50, **km** 3/5/8/12/15/30/50/80, **nm** 2/3/5/7/10/15/25/40. Values sit nearest the previous mile-based distances, so a saved `scale_index` lands at about the same zoom after a unit switch.
- Ring pixel radii never move. Only what the rings mean (labels, data-fetch radii) shifts a few percent.
- The scale tag, ring labels, portal range picker (options now read "2mi / 3km / 2nm"), and the on-device range cycle all read the active unit's table.
- Switching units refetches the basemap and overlays, since real coverage changes slightly.

## Testing

New `TestRoundUnitBands` cases in `tests/test_scale.py`: table lengths match, display values are exactly the round numbers, band tags format in-unit, snapping works within each unit's table, and the outer ring label is exact. Existing scale/zoom/airport tests pass unchanged.