### PR TITLE
Skip favourites that duplicate Home in the location swipe cycle

### DIFF
--- a/flightscnr/tests/test_favourite_cycle.py
+++ b/flightscnr/tests/test_favourite_cycle.py
@@ -78,6 +78,30 @@ class TestFavouriteCycle(unittest.TestCase):
         idx, _lat, _lon, label = self._cycle()
         self.assertEqual((idx, label), (0, "KSNA"))
 
+    def test_cycle_skips_favourite_that_duplicates_home(self):
+        # Home was set from the first favourite (identical coords) — the
+        # cycle must not visit the same place twice.
+        self.fav._state["home"] = {"lat": 33.68, "lon": -117.87}
+        idx, _lat, _lon, label = self._cycle()
+        self.assertEqual((idx, label), (1, "KLAX"))
+        idx, _lat, _lon, label = self._cycle()
+        self.assertEqual(label, "Home")
+
+    def test_cycle_skips_dup_mid_list(self):
+        self.fav._state["home"] = {"lat": 33.94, "lon": -118.41}  # == KLAX
+        idx, _lat, _lon, label = self._cycle()
+        self.assertEqual((idx, label), (0, "KSNA"))
+        idx, _lat, _lon, label = self._cycle()
+        self.assertEqual(label, "Home")
+
+    def test_all_favourites_dup_home_goes_straight_home(self):
+        self.fav._state["locations"] = [
+            {"id": "a", "name": "KSNA", "icao": "KSNA", "lat": 37.0, "lon": -122.0},
+        ]
+        idx, lat, _lon, label = self._cycle()
+        self.assertEqual(label, "Home")
+        self.assertAlmostEqual(lat, 37.0)
+
     def test_cycle_with_no_favorites_stays_home(self):
         self.fav._state["locations"] = []
         idx, lat, _lon, label = self._cycle()

--- a/flightscnr/utilities/favourite_locations.py
+++ b/flightscnr/utilities/favourite_locations.py
@@ -392,9 +392,27 @@ def delete_location(entry_id: str) -> bool:
     return True
 
 
+# Favourites this close to Home (degrees, ≈50 m) are the same place — a
+# favourite promoted to Home stays in the list but leaves the swipe cycle.
+_HOME_DUP_EPS_DEG = 0.0005
+
+
+def _duplicates_home(loc: dict) -> bool:
+    try:
+        h_lat, h_lon = home_coords()
+        return (
+            abs(float(loc["lat"]) - h_lat) < _HOME_DUP_EPS_DEG
+            and abs(float(loc["lon"]) - h_lon) < _HOME_DUP_EPS_DEG
+        )
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
 def cycle_active() -> tuple[int, float, float, str]:
     """Advance Home → fav0 → … → Home (Custom joins as its own step before Home).
 
+    Favourites whose coordinates duplicate Home are skipped, so setting a
+    favourite as Home never makes the cycle visit the same place twice.
     Returns ``(index, lat, lon, label)``. Caller should persist coordinates to
     ``location.json`` so reboot restores this center.
     """
@@ -404,34 +422,22 @@ def cycle_active() -> tuple[int, float, float, str]:
     n = len(locs)
     cur = int(_state.get("active_index", HOME_INDEX))
 
+    def _go_home() -> tuple[int, float, float, str]:
+        _set_active_index(HOME_INDEX)
+        lat, lon = home_coords()
+        return HOME_INDEX, lat, lon, "Home"
+
+    def _next_from(start: int) -> tuple[int, float, float, str]:
+        for i in range(max(0, start), n):
+            loc = locs[i]
+            if _duplicates_home(loc):
+                continue
+            _set_active_index(i)
+            return i, float(loc["lat"]), float(loc["lon"]), loc["name"]
+        return _go_home()
+
     # Order: Home → favs → (back to Home). Custom is not in the cycle list;
     # the next tap from Custom goes to the first favourite (or Home if none).
-    if cur == CUSTOM_INDEX:
-        if n == 0:
-            _set_active_index(HOME_INDEX)
-            lat, lon = home_coords()
-            return HOME_INDEX, lat, lon, "Home"
-        _set_active_index(0)
-        loc = locs[0]
-        return 0, float(loc["lat"]), float(loc["lon"]), loc["name"]
-
-    if n == 0:
-        _set_active_index(HOME_INDEX)
-        lat, lon = home_coords()
-        return HOME_INDEX, lat, lon, "Home"
-
-    if cur < 0:
-        # Home → first favourite
-        _set_active_index(0)
-        loc = locs[0]
-        return 0, float(loc["lat"]), float(loc["lon"]), loc["name"]
-
-    nxt = cur + 1
-    if nxt >= n:
-        _set_active_index(HOME_INDEX)
-        lat, lon = home_coords()
-        return HOME_INDEX, lat, lon, "Home"
-
-    _set_active_index(nxt)
-    loc = locs[nxt]
-    return nxt, float(loc["lat"]), float(loc["lon"]), loc["name"]
+    if cur == CUSTOM_INDEX or cur < 0:
+        return _next_from(0)
+    return _next_from(cur + 1)


### PR DESCRIPTION
Setting a favourite as Home copies its coordinates into the home slot but keeps the favourite in the list, so the radar's location swipe visited the same place twice: Home, then the favourite it came from, before moving on.

`cycle_active()` now skips any favourite within ~50 m of Home. The favourite stays in the list (portal, labels) — it just leaves the cycle. If every favourite duplicates Home, the cycle collapses to Home alone.

New cases in `tests/test_favourite_cycle.py`: first-slot dup, mid-list dup, and the all-dups collapse; the existing wrap tests pass unchanged.