### PR TITLE
Resolve NASR services for synthetic K-prefixed idents (KF70 → F70)

### DIFF
--- a/flightscnr/tests/test_chart_airport_icons.py
+++ b/flightscnr/tests/test_chart_airport_icons.py
@@ -85,6 +85,20 @@ class TestFaaDistill:
         assert faa_airports.lookup("ksan")["towered"] is True
         assert faa_airports.lookup("EGLL") is None
 
+    def test_lookup_retries_without_synthetic_k_prefix(self, monkeypatch):
+        # OurAirports idents K-prefix some fields with no real ICAO code
+        # (KF70, KL65); NASR knows them only by the FAA local id.
+        monkeypatch.setattr(faa_airports, "_loaded", True)
+        monkeypatch.setattr(
+            faa_airports, "_db",
+            {"F70": {"fuel": True, "beacon": True, "towered": False}},
+        )
+        assert faa_airports.lookup("KF70")["fuel"] is True
+        assert faa_airports.lookup("F70")["fuel"] is True
+        # Never strip a K that resolves on its own (KSAN stays KSAN),
+        # and never invent a hit for genuinely unknown idents.
+        assert faa_airports.lookup("KZZZ") is None
+
 
 class TestTowerFrequencies:
     def test_rows_with_twr_type_are_towered(self):

--- a/flightscnr/utilities/faa_airports.py
+++ b/flightscnr/utilities/faa_airports.py
@@ -140,9 +140,17 @@ def _load() -> None:
 
 
 def lookup(ident: str) -> dict | None:
-    """{"fuel", "beacon", "towered"} for a US airport ident, else None."""
+    """{"fuel", "beacon", "towered"} for a US airport ident, else None.
+
+    Falls back to the FAA local id for synthetic K-prefixed idents
+    (OurAirports lists fields like F70 as KF70; NASR has no such ICAO).
+    """
     _load()
-    return _db.get((ident or "").strip().upper())
+    key = (ident or "").strip().upper()
+    rec = _db.get(key)
+    if rec is None and len(key) == 4 and key.startswith("K"):
+        rec = _db.get(key[1:])
+    return rec
 
 
 def refresh() -> None:


### PR DESCRIPTION
Chart-style symbols showed no fuel tines or beacon stars at fields like F70 (French Valley) and L65 even though NASR lists services for them.

OurAirports K-prefixes fields that have no real ICAO code (KF70, KL65); FAA NASR keys them by the FAA local id only, so the lookup missed and fell back to no-services. `faa_airports.lookup` now retries without the K when a 4-letter K-ident misses. A real hit (KSAN) is never touched, and genuinely unknown idents still return None — the K block is US-only, and NASR already keys both id forms, so the strip can't cross-match a foreign field.

Test added to `tests/test_chart_airport_icons.py` covering the retry, the no-strip-on-hit case, and unknown idents.