### PR TITLE
Use display-unit bands for map, rain, and ATC radius

### DIFF
--- a/flightscnr/display/round_touch/map_bg.py
+++ b/flightscnr/display/round_touch/map_bg.py
@@ -391,7 +391,7 @@ def _basemap_render_scale(
         return 1.0
     if scale_index < 0 or scale_index >= len(scale.SCALE_BANDS):
         return 1.0
-    outer_km = scale.SCALE_BANDS[scale_index]["label_km"]
+    outer_km = scale.bands()[scale_index]["label_km"]
     target_m_per_px = outer_km * 1000.0 / theme.GRID_OUTER_RADIUS
     if target_m_per_px <= 0:
         return 1.0
@@ -841,7 +841,7 @@ def _build_background(scale_index: int, style: str | None = None) -> pygame.Surf
     if provider == "black":
         return _build_flat_black_background()
     home_lat, home_lon = LOCATION_HOME[0], LOCATION_HOME[1]
-    outer_km = scale.SCALE_BANDS[scale_index]["label_km"]
+    outer_km = scale.bands()[scale_index]["label_km"]
     px_per_km = theme.GRID_OUTER_RADIUS / outer_km
     zoom = _zoom_for_scale(home_lat, px_per_km, provider)
     render_scale = _basemap_render_scale(home_lat, scale_index, zoom, provider)
@@ -1168,7 +1168,7 @@ def _basemap_zoom_for_home(home_lat: float) -> int | None:
     idx = scale.active_index()
     if idx < 0 or idx >= len(scale.SCALE_BANDS):
         return None
-    outer_km = scale.SCALE_BANDS[idx]["label_km"]
+    outer_km = scale.bands()[idx]["label_km"]
     px_per_km = theme.GRID_OUTER_RADIUS / outer_km
     return _zoom_for_scale(home_lat, px_per_km, _resolved_style())
 

--- a/flightscnr/display/round_touch/rainviewer_overlay.py
+++ b/flightscnr/display/round_touch/rainviewer_overlay.py
@@ -429,7 +429,7 @@ def _build_overlay(
         return None
 
     home_lat, home_lon = float(LOCATION_HOME[0]), float(LOCATION_HOME[1])
-    outer_km = scale.SCALE_BANDS[scale_index]["label_km"]
+    outer_km = scale.bands()[scale_index]["label_km"]
     px_per_km = theme.GRID_OUTER_RADIUS / outer_km
     zoom = MAX_ZOOM
 

--- a/flightscnr/display/round_touch/scale.py
+++ b/flightscnr/display/round_touch/scale.py
@@ -176,8 +176,9 @@ def preset_labels_mi() -> str:
 def index_for_radius_nm(radius_nm: float) -> int:
     """Scale band index that fits the configured search radius."""
     radius_km = radius_nm * 1.852
-    best = len(SCALE_BANDS) - 1
-    for i, band in enumerate(SCALE_BANDS):
+    unit_bands = bands()
+    best = len(unit_bands) - 1
+    for i, band in enumerate(unit_bands):
         if band["coverage_km"] >= radius_km:
             best = i
             break

--- a/flightscnr/tests/test_atc_audio.py
+++ b/flightscnr/tests/test_atc_audio.py
@@ -954,7 +954,35 @@ class VisibleAirportsRadiusTests(unittest.TestCase):
         ):
             radius = atc_audio._radar_airport_radius_km()
         self.assertEqual(scale_mod.active_index(), last_idx)
-        self.assertGreater(radius, scale_mod.SCALE_BANDS[1]["coverage_km"])
+        self.assertGreater(radius, scale_mod.bands()[1]["coverage_km"])
+
+    def test_radius_follows_display_unit_bands(self):
+        from display.round_touch import scale as scale_mod
+        from display.round_touch import settings, theme
+        from utilities import atc_audio
+
+        scale_mod.select(4)
+        screen_r = theme.VISIBLE_RADIUS - theme.BEYOND_RING_MARGIN
+        edge_factor = float(screen_r) / float(theme.GRID_OUTER_RADIUS)
+        with mock.patch(
+            "display.round_touch.settings.scale_index", return_value=4
+        ), mock.patch.object(settings, "distance_units", return_value="km"):
+            km_radius = atc_audio._radar_airport_radius_km()
+        with mock.patch(
+            "display.round_touch.settings.scale_index", return_value=4
+        ), mock.patch.object(settings, "distance_units", return_value="mi"):
+            mi_radius = atc_audio._radar_airport_radius_km()
+        self.assertAlmostEqual(
+            km_radius,
+            scale_mod.bands("km")[4]["coverage_km"] * edge_factor,
+            places=3,
+        )
+        self.assertAlmostEqual(
+            mi_radius,
+            scale_mod.bands("mi")[4]["coverage_km"] * edge_factor,
+            places=3,
+        )
+        self.assertGreater(abs(km_radius - mi_radius), 0.5)
 
     def test_visible_airports_queries_settings_radius(self):
         from utilities import atc_audio

--- a/flightscnr/utilities/atc_audio.py
+++ b/flightscnr/utilities/atc_audio.py
@@ -872,7 +872,7 @@ def _radar_airport_radius_km() -> float:
         scale_mod.select(idx)
     except Exception:
         pass
-    band = scale_mod.SCALE_BANDS[idx]
+    band = scale_mod.bands()[idx]
     try:
         screen_r = theme.VISIBLE_RADIUS - theme.BEYOND_RING_MARGIN
         return float(band["coverage_km"]) * (float(screen_r) / float(theme.GRID_OUTER_RADIUS))


### PR DESCRIPTION
## Summary
- Follow-up to #154: map_bg, rainviewer, and ATC airport radius use `scale.bands()` instead of mile-only `SCALE_BANDS`
- `index_for_radius_nm()` also respects the active display unit