### PR TITLE
Range rings sit at round distances, not exact thirds

### DIFF
--- a/flightscnr/display/round_touch/scale.py
+++ b/flightscnr/display/round_touch/scale.py
@@ -158,6 +158,37 @@ def display_value_for_index(index: int, units: str = "mi") -> float:
     return bands(u)[idx]["value"]
 
 
+def ring_values(index: int, units: str | None = None) -> list[float]:
+    """Three ring distances for a band: two round inner rings + the range.
+
+    Inner rings sit near 1/3 and 2/3 of the range but snap to round
+    numbers in the display unit, so ring labels never show decimals
+    (beyond .5 at the smallest ranges). The radar draws the rings at the
+    matching fractional radii.
+    """
+    u = _resolve_units(units)
+    v = float(bands(u)[max(0, min(int(index), len(SCALE_BANDS) - 1))]["value"])
+    step = 0.5 if v < 5 else (1.0 if v < 30 else (5.0 if v < 60 else 10.0))
+
+    def snap(x: float) -> float:
+        return round(x / step) * step
+
+    d1 = snap(v / 3.0)
+    d2 = snap(2.0 * v / 3.0)
+    if d1 <= 0:
+        d1 = step
+    if d2 <= d1:
+        d2 = d1 + step
+    if d2 >= v:
+        d2 = v - step
+    if d1 >= d2:
+        d1 = d2 - step if d2 - step > 0 else d2 / 2.0
+    out = []
+    for d in (d1, d2, v):
+        out.append(int(d) if float(d).is_integer() else float(d))
+    return out
+
+
 def format_display_value(index: int, units: str = "mi") -> str:
     """Format range for the portal text box."""
     value = display_value_for_index(index, units)

--- a/flightscnr/display/round_touch/screens/radar.py
+++ b/flightscnr/display/round_touch/screens/radar.py
@@ -585,8 +585,11 @@ def _draw_grid(surface, *, calibrate: bool = False):
     line_w = max(1, theme.s(2))
     facing = settings.effective_facing_deg()
     if settings.show_range_rings():
-        for ring in range(1, theme.RING_COUNT + 1):
-            r = theme.GRID_OUTER_RADIUS * ring // theme.RING_COUNT
+        # Rings sit at round distances (scale.ring_values), not exact thirds.
+        ring_vals = scale.ring_values(scale.active_index())
+        outer_val = float(ring_vals[-1])
+        for d in ring_vals:
+            r = int(round(theme.GRID_OUTER_RADIUS * float(d) / outer_val))
             draw.draw_dashed_circle(surface, center, r, theme.GRID, width=line_w)
 
         cx, cy = theme.CENTER_X, theme.CENTER_Y
@@ -632,12 +635,13 @@ def _draw_grid(surface, *, calibrate: bool = False):
 
     use_units = settings.distance_units()
     scale_font = draw.load_font(theme.FONT_SCALE_LABEL, bold=True)
-    outer_km = scale.active_band()["label_km"]
-    for ring in range(1, theme.RING_COUNT + 1):
-        ring_km = outer_km * ring / theme.RING_COUNT
-        label = scale.format_scale_tag(ring_km, use_units)
-        r = theme.GRID_OUTER_RADIUS * ring // theme.RING_COUNT
-        gap = theme.SCALE_GAP_OUTER_RING_KM if ring == theme.RING_COUNT and use_units == "km" else theme.SCALE_GAP_FROM_OUTER_RING
+    ring_vals = scale.ring_values(scale.active_index(), use_units)
+    outer_val = float(ring_vals[-1])
+    for i, ring_d in enumerate(ring_vals):
+        is_outer = i == len(ring_vals) - 1
+        label = f"{ring_d:g}{use_units}"
+        r = int(round(theme.GRID_OUTER_RADIUS * float(ring_d) / outer_val))
+        gap = theme.SCALE_GAP_OUTER_RING_KM if is_outer and use_units == "km" else theme.SCALE_GAP_FROM_OUTER_RING
         label_r = r - gap
         rad = math.radians(theme.SCALE_LABEL_BEARING_DEG - facing - 90)
         x = theme.CENTER_X + int(label_r * math.cos(rad))

--- a/flightscnr/tests/test_scale.py
+++ b/flightscnr/tests/test_scale.py
@@ -81,5 +81,36 @@ class TestRoundUnitBands(unittest.TestCase):
             self.assertEqual(scale.format_scale_tag(outer_km, "nm"), "10nm")
 
 
+class TestRoundRingValues(unittest.TestCase):
+    """Inner rings sit at round distances, not exact thirds."""
+
+    def test_ring_values_are_round_and_increasing(self):
+        for units in ("mi", "km", "nm"):
+            for i in range(8):
+                vals = scale.ring_values(i, units)
+                v = scale.display_value_for_index(i, units)
+                self.assertEqual(len(vals), 3)
+                self.assertEqual(vals[-1], v)
+                self.assertTrue(0 < vals[0] < vals[1] < vals[2])
+                step = 0.5 if v < 5 else (1 if v < 30 else (5 if v < 60 else 10))
+                for d in vals[:2]:
+                    self.assertAlmostEqual((d / step) % 1.0, 0.0, places=6,
+                                           msg=f"{units} range {v}: ring {d}")
+
+    def test_known_examples(self):
+        self.assertEqual(scale.ring_values(4, "mi"), [3, 7, 10])
+        self.assertEqual(scale.ring_values(4, "km"), [5, 10, 15])
+        self.assertEqual(scale.ring_values(7, "nm"), [15, 25, 40])
+        self.assertEqual(scale.ring_values(0, "mi"), [0.5, 1.5, 2])
+
+    def test_radar_uses_ring_values(self):
+        import inspect
+
+        from display.round_touch.screens import radar
+
+        src = inspect.getsource(radar)
+        self.assertIn("scale.ring_values", src)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #154. The selected range became a round number, but the two inner rings were still labeled at exact thirds — a 10 nm range showed 3.3 / 6.7 / 10.

`scale.ring_values` now snaps the inner rings to round distances near 1/3 and 2/3 of the range (0.5 steps under 5, whole numbers under 30, then 5s and 10s), and the radar draws each ring at its true fractional radius. Examples: 10 → 3 / 7 / 10, 15 km → 5 / 10 / 15, 40 nm → 15 / 25 / 40, 2 → 0.5 / 1.5 / 2. Labels are honest — each ring really is at the distance it names; the rings shift position slightly instead of the labels lying.

Tests in `tests/test_scale.py`: every band in every unit yields strictly-increasing round multiples with the range as the outer ring, plus known examples and the radar wiring.