### PR TITLE
Tracked flight page gets the contour texture background

### DIFF
--- a/flightscnr/display/round_touch/screens/tracked.py
+++ b/flightscnr/display/round_touch/screens/tracked.py
@@ -1214,7 +1214,7 @@ def draw_tracked(
     _marquee_active_keys = set()
     del scroll_offset  # tracked page does not scroll vertically
 
-    draw.fill_background(surface)
+    draw.fill_background_textured(surface)
     raw_callsign = (callsign or load_tracked_callsign() or "").strip().upper()
     display_id = raw_callsign
     if tracked_data:

--- a/flightscnr/tests/test_follow_footer_empty.py
+++ b/flightscnr/tests/test_follow_footer_empty.py
@@ -38,6 +38,12 @@ class TestFooterLayoutConsistency:
         assert tracked.footer_button_kinds(None) == ("radar",)
         assert tracked.footer_button_kinds({"callsign": "N12345"}) == ("pin", "radar")
 
+    def test_tracked_page_uses_contour_background(self):
+        import inspect
+
+        src = inspect.getsource(tracked.draw_tracked)
+        assert "fill_background_textured" in src
+
     def test_tap_handlers_resolve_display_data(self):
         import inspect
 


### PR DESCRIPTION
Radar › Track › \<flight\> was the last detail page still on plain black. It now uses the same subtle topo contour fill (`draw.fill_background_textured`) as the other detail and settings screens, so the whole secondary-screen family matches.

One-line change plus a source-pinning test in `tests/test_follow_footer_empty.py`.

## Screenshot

Rendered on the Pi, masked to the round display.

<img src="https://raw.githubusercontent.com/canuk/FlightScnr_Pi/screenshots/round_tracked_texture.png" width="380" alt="Tracked page with contour texture">
