### PR TITLE
Make slider drags more forgiving on actual use

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -3264,12 +3264,15 @@ class RoundTouchDisplay:
                     self.input.consume_scroll_drag()
                     return
         if self.screen == SCREEN_SETTINGS and self.settings_page == info.PAGE_ATC:
-            if self._atc_volume_slider_active:
+            if self._atc_volume_slider_active or self._lofi_volume_slider_active:
                 self.input.consume_scroll_drag()
                 return
             if self.input.is_dragging():
                 pos = self.input.drag_pos()
-                if pos and info.atc_volume_slider_at(pos[0], pos[1], self._scroll.offset):
+                if pos and (
+                    info.atc_volume_slider_at(pos[0], pos[1], self._scroll.offset)
+                    or info.lofi_volume_slider_at(pos[0], pos[1], self._scroll.offset)
+                ):
                     self.input.consume_scroll_drag()
                     return
         if self.screen in (

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -209,6 +209,7 @@ class RoundTouchDisplay:
         # Already-rotated content+bezel (no ring) for fast display blit.
         self._timeout_rot_base: pygame.Surface | None = None
         self._prev_timeout_ring_frac: float | None = None
+        self._last_slider_draw = 0.0
         self._display_focus = 0
         self._system_confirm: str | None = None
         # Settings list picker kind (ATC + other multi-option rows), or None.
@@ -4944,7 +4945,17 @@ class RoundTouchDisplay:
                     or self._update_atc_volume_slider_drag()
                     or self._update_radar_hud_volume_drag()
                 ):
-                    self._safe_draw()
+                    # Settings pages repaint in full — throttle mid-drag
+                    # redraws so the loop keeps sampling the finger instead
+                    # of choking on layout. The release frame always draws.
+                    now_drag = time.time()
+                    if (
+                        now_drag - self._last_slider_draw >= 0.05
+                        or not self.input.is_dragging()
+                    ):
+                        self._safe_draw()
+                        self._last_slider_draw = now_drag
+                        self._last_static_draw = now_drag
                     self._last_radar_draw = time.time()
 
                 now = time.time()

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -4953,6 +4953,10 @@ class RoundTouchDisplay:
                     # of choking on layout. The release frame always draws.
                     now_drag = time.time()
                     self._note_activity()
+                    if self.screen == SCREEN_SETTINGS:
+                        # ATC labels shell out to bluetoothctl / mpv IPC on
+                        # rebuild — freeze them while the finger drags.
+                        info.hold_atc_labels()
                     if (
                         now_drag - self._last_slider_draw >= 0.05
                         or not self.input.is_dragging()

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -2091,6 +2091,21 @@ class RoundTouchDisplay:
             return
         self._apply_favourite_center(float(entry["lat"]), float(entry["lon"]))
 
+    def _slider_drag_armed(self) -> bool:
+        """Any slider currently owning the finger? Others must not arm —
+        a sweep that wanders through another slider's hit band mid-drag
+        used to let that slider steal the gesture (focus jumped rows)."""
+        return bool(
+            self._brightness_slider_active
+            or self._vfr_opacity_slider_active
+            or self._atc_volume_slider_active
+            or self._lofi_volume_slider_active
+            or self._hud_opacity_slider_active
+            or self._hud_volume_slider_kind
+            or self._radar_hud_volume_drag
+            or self._rgb_slider_channel is not None
+        )
+
     def _apply_atc_volume_slider(self, x: int, *, persist: bool = True) -> bool:
         from utilities import atc_audio
 
@@ -2253,6 +2268,8 @@ class RoundTouchDisplay:
             return False
         x, y = pos
         if not self._hud_opacity_slider_active:
+            if self._slider_drag_armed():
+                return False
             if not info.hud_opacity_slider_at(x, y, self._scroll.offset):
                 return False
             self._hud_opacity_slider_active = True
@@ -2329,6 +2346,8 @@ class RoundTouchDisplay:
             return False
         x, y = pos
         if self._hud_volume_slider_kind is None:
+            if self._slider_drag_armed():
+                return False
             hit = info.hud_volume_slider_at(x, y, self._scroll.offset)
             if not hit:
                 return False
@@ -2377,6 +2396,8 @@ class RoundTouchDisplay:
             return False
         x, y = pos
         if not self._lofi_volume_slider_active:
+            if self._slider_drag_armed():
+                return False
             if not info.lofi_volume_slider_at(x, y, self._scroll.offset):
                 return False
             self._lofi_volume_slider_active = True
@@ -2407,6 +2428,8 @@ class RoundTouchDisplay:
             return False
         x, y = pos
         if not self._atc_volume_slider_active:
+            if self._slider_drag_armed():
+                return False
             if not info.atc_volume_slider_at(x, y, self._scroll.offset):
                 return False
             self._atc_volume_slider_active = True
@@ -3412,6 +3435,8 @@ class RoundTouchDisplay:
             return False
         x, y = pos
         if not self._brightness_slider_active:
+            if self._slider_drag_armed():
+                return False
             if not info.brightness_slider_at(x, y, self._scroll.offset):
                 return False
             self._brightness_slider_active = True
@@ -3452,6 +3477,8 @@ class RoundTouchDisplay:
             return False
         x, y = pos
         if not self._vfr_opacity_slider_active:
+            if self._slider_drag_armed():
+                return False
             if not info.vfr_opacity_slider_at(x, y, self._scroll.offset):
                 return False
             self._vfr_opacity_slider_active = True
@@ -3574,6 +3601,7 @@ class RoundTouchDisplay:
                 x, y, self._scroll.offset
             ):
                 self._apply_atc_volume_slider(x, persist=True)
+                return
             elif self.settings_page == info.PAGE_ATC and info.lofi_volume_slider_at(
                 x, y, self._scroll.offset
             ):

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -4949,6 +4949,7 @@ class RoundTouchDisplay:
                     # redraws so the loop keeps sampling the finger instead
                     # of choking on layout. The release frame always draws.
                     now_drag = time.time()
+                    self._note_activity()
                     if (
                         now_drag - self._last_slider_draw >= 0.05
                         or not self.input.is_dragging()
@@ -5226,7 +5227,9 @@ class RoundTouchDisplay:
                             != self._timeout_content_cache_key()
                         )
                         ring_iv = theme.SWEEP_FRAME_MS / 1000.0
-                        if need_content:
+                        if need_content and (
+                            now - self._last_timeout_content_draw >= 0.20
+                        ):
                             self._last_timeout_content_draw = now
                             self._last_static_draw = now
                             self._safe_draw()

--- a/flightscnr/display/round_touch/radar_hud.py
+++ b/flightscnr/display/round_touch/radar_hud.py
@@ -1361,11 +1361,9 @@ def hit_volume_slider(x: int, y: int) -> bool:
 
 
 def volume_slider_drag_band(x: int, y: int) -> bool:
-    """True while a sticky HUD volume drag should keep mapping screen X."""
-    if not _volume_popover or _slider_track.width <= 0:
-        return False
-    pad_y = theme.s(64)  # forgive arced thumbs on the round glass
-    return (_slider_track.top - pad_y) <= y <= (_slider_track.bottom + pad_y)
+    """Armed HUD volume drags capture the finger until release."""
+    del x, y
+    return bool(_volume_popover) and _slider_track.width > 0
 
 
 def hit_hud(x: int, y: int) -> bool:

--- a/flightscnr/display/round_touch/radar_hud.py
+++ b/flightscnr/display/round_touch/radar_hud.py
@@ -1364,7 +1364,7 @@ def volume_slider_drag_band(x: int, y: int) -> bool:
     """True while a sticky HUD volume drag should keep mapping screen X."""
     if not _volume_popover or _slider_track.width <= 0:
         return False
-    pad_y = theme.s(28)
+    pad_y = theme.s(64)  # forgive arced thumbs on the round glass
     return (_slider_track.top - pad_y) <= y <= (_slider_track.bottom + pad_y)
 
 

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -1670,7 +1670,9 @@ def _atc_volume_slider_metrics() -> tuple[int, int, int, int]:
     label_w = body_font.size("Volume")[0]
     value_w = body_font.size(f"{settings.ATC_VOLUME_MAX}%")[0]
     track_w = theme.s(100)
-    row_h = body_font.get_height() + theme.s(8)
+    # Match the settings-row pitch exactly — a taller slider row made the
+    # ATC page look unevenly spaced.
+    row_h = body_font.get_height() + theme.s(6)
     return track_w, row_h, label_w, value_w
 
 
@@ -1908,7 +1910,7 @@ def _draw_lofi_volume_slider_row(surface, ry: int, focused: bool) -> None:
         pad = theme.s(4)
         focus = pygame.Rect(left_x - pad, ry - pad, block_w + pad * 2, row_h + pad)
         pygame.draw.rect(surface, theme.GRID, focus, max(1, theme.s(1)))
-    label = body_font.render("Lofi vol", True, theme.MUTED)
+    label = body_font.render("Lofi Vol", True, theme.MUTED)
     surface.blit(label, (left_x, int(ry + (row_h - text_h) // 2)))
     track_cy = int(ry + row_h // 2)
     track_rect = pygame.Rect(track_x, track_cy - max(2, theme.s(2)), track_w, max(4, theme.s(4)))

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -173,6 +173,16 @@ SYSTEM_ACTIONS = (
 # Cache labels briefly so the perimeter countdown stays smooth like other pages.
 _ATC_LABEL_TTL_S = 0.4
 _atc_rows_cache: tuple[float, tuple[str, ...]] | None = None
+# While a slider drag is live, serve stale labels no matter their age —
+# the rebuild shells out to bluetoothctl and polls mpv IPC, which blocks
+# the UI thread for hundreds of ms and wrecks the drag.
+_atc_rows_hold_until = 0.0
+
+
+def hold_atc_labels(seconds: float = 1.0) -> None:
+    """Freeze ATC row labels briefly (called each frame during drags)."""
+    global _atc_rows_hold_until
+    _atc_rows_hold_until = time.monotonic() + seconds
 _atc_picker_cache: dict[str, tuple[float, tuple[tuple[str, str, bool], ...]]] = {}
 
 
@@ -1845,7 +1855,7 @@ def _atc_row_labels() -> list[str]:
     now = time.monotonic()
     if _atc_rows_cache is not None:
         ts, rows = _atc_rows_cache
-        if now - ts < _ATC_LABEL_TTL_S:
+        if now - ts < _ATC_LABEL_TTL_S or now < _atc_rows_hold_until:
             return list(rows)
 
     st: dict | None = None

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -1214,17 +1214,16 @@ def _in_settings_body(y: int) -> bool:
 def slider_drag_band_contains(
     hit: pygame.Rect, y: int, *, pad_y: int | None = None
 ) -> bool:
-    """True while a sticky horizontal drag should keep mapping screen X.
+    """Armed slider drags capture the finger completely until release.
 
-    After a slider arms, X may leave the track (clamped to 0–100%); leaving this
-    vertical band cancels the drag so taps elsewhere on the screen cannot steal
-    the value (ATC volume / brightness sticky-X bug).
+    A finger on a slider covers it, so people naturally drift up or down
+    while sweeping left/right — the drag keeps mapping screen X wherever
+    the finger goes. Arming still requires pressing the slider itself, and
+    every handler releases (and persists) the moment the finger lifts, so
+    taps elsewhere can never steal the value.
     """
-    if pad_y is None:
-        # Generous: a thumb sweeping a slider on the round glass arcs well
-        # off the row. Only a far wander (another region entirely) cancels.
-        pad_y = theme.s(64)
-    return (hit.top - pad_y) <= y <= (hit.bottom + pad_y)
+    del hit, y, pad_y
+    return True
 
 
 def display_row_at(x: int, y: int, page: int, scroll_offset: int = 0) -> int | None:

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -1221,7 +1221,9 @@ def slider_drag_band_contains(
     the value (ATC volume / brightness sticky-X bug).
     """
     if pad_y is None:
-        pad_y = theme.s(28)
+        # Generous: a thumb sweeping a slider on the round glass arcs well
+        # off the row. Only a far wander (another region entirely) cancels.
+        pad_y = theme.s(64)
     return (hit.top - pad_y) <= y <= (hit.bottom + pad_y)
 
 

--- a/flightscnr/tests/test_lofi_audio.py
+++ b/flightscnr/tests/test_lofi_audio.py
@@ -405,18 +405,17 @@ class TestAtcPageVolume:
 
 
 class TestSliderDragTolerance:
-    def test_drag_band_forgives_arced_thumbs(self):
+    def test_armed_drags_capture_the_finger_anywhere(self):
         import pygame
 
         from display.round_touch import theme
         from display.round_touch.screens import info
 
         hit = pygame.Rect(100, 300, 400, 40)
-        # A thumb arcing ~60px off the row must NOT cancel the drag.
+        # Fingers cover the slider they drag — any Y keeps the drag alive.
         assert info.slider_drag_band_contains(hit, 300 - theme.s(56)) is True
-        assert info.slider_drag_band_contains(hit, 340 + theme.s(56)) is True
-        # Far-off wanders still cancel (the sticky-X steal guard).
-        assert info.slider_drag_band_contains(hit, 340 + theme.s(90)) is False
+        assert info.slider_drag_band_contains(hit, 340 + theme.s(200)) is True
+        assert info.slider_drag_band_contains(hit, 0) is True
 
 
 class TestAtcLofiGating:

--- a/flightscnr/tests/test_lofi_audio.py
+++ b/flightscnr/tests/test_lofi_audio.py
@@ -404,6 +404,17 @@ class TestAtcPageVolume:
         assert len(info._atc_row_labels()) == len(info.ATC_ACTIONS)
 
 
+class TestScrollStandsDownForSliders:
+    def test_lofi_slider_gates_the_page_scroll(self):
+        import inspect
+
+        from display.round_touch import app as app_mod
+
+        src = inspect.getsource(app_mod)
+        assert "self._atc_volume_slider_active or self._lofi_volume_slider_active" in src
+        assert "info.lofi_volume_slider_at(pos[0], pos[1], self._scroll.offset)" in src
+
+
 class TestSliderDragTolerance:
     def test_armed_drags_capture_the_finger_anywhere(self):
         import pygame

--- a/flightscnr/tests/test_lofi_audio.py
+++ b/flightscnr/tests/test_lofi_audio.py
@@ -404,6 +404,21 @@ class TestAtcPageVolume:
         assert len(info._atc_row_labels()) == len(info.ATC_ACTIONS)
 
 
+class TestSliderDragTolerance:
+    def test_drag_band_forgives_arced_thumbs(self):
+        import pygame
+
+        from display.round_touch import theme
+        from display.round_touch.screens import info
+
+        hit = pygame.Rect(100, 300, 400, 40)
+        # A thumb arcing ~60px off the row must NOT cancel the drag.
+        assert info.slider_drag_band_contains(hit, 300 - theme.s(56)) is True
+        assert info.slider_drag_band_contains(hit, 340 + theme.s(56)) is True
+        # Far-off wanders still cancel (the sticky-X steal guard).
+        assert info.slider_drag_band_contains(hit, 340 + theme.s(90)) is False
+
+
 class TestAtcLofiGating:
     def test_lofi_rows_hidden_without_tracks(self, monkeypatch):
         from display.round_touch.screens import info

--- a/flightscnr/tests/test_lofi_audio.py
+++ b/flightscnr/tests/test_lofi_audio.py
@@ -415,6 +415,23 @@ class TestScrollStandsDownForSliders:
         assert "info.lofi_volume_slider_at(pos[0], pos[1], self._scroll.offset)" in src
 
 
+class TestAtcLabelFreeze:
+    def test_hold_serves_stale_labels_without_status_calls(self, monkeypatch):
+        import time as _t
+
+        from display.round_touch.screens import info
+        from utilities import atc_audio
+
+        calls = []
+        monkeypatch.setattr(atc_audio, "status", lambda: calls.append(1) or {})
+        info._atc_rows_cache = (_t.monotonic() - 60.0, ("stale", "rows"))
+        info.hold_atc_labels(5.0)
+        assert info._atc_row_labels() == ["stale", "rows"]
+        assert not calls  # no bluetoothctl / IPC rebuild during the hold
+        info._atc_rows_hold_until = 0.0
+        info._atc_rows_cache = None
+
+
 class TestSliderDragTolerance:
     def test_armed_drags_capture_the_finger_anywhere(self):
         import pygame

--- a/flightscnr/utilities/atc_audio.py
+++ b/flightscnr/utilities/atc_audio.py
@@ -1186,10 +1186,16 @@ def _effective_atc_ui_volume(ui_percent: float | int | None = None) -> float:
 
 
 def set_volume(percent: int, *, persist: bool = True) -> int:
-    """Clamp, optionally persist, and apply volume to a running mpv (if any)."""
+    """Clamp, optionally persist, and apply volume to a running mpv (if any).
+
+    ``persist=False`` marks a mid-drag update: only the cheap mpv softvol
+    IPC runs. The OS-mixer subprocesses (wpctl/pactl/amixer, seconds of
+    UI-thread stall) run on the final persisting call alone.
+    """
     value = _settings().set_atc_volume(percent, persist=persist)
-    # Keep OS mixer at full while ATC is in use; softvol handles finer gain.
-    _ensure_system_output_volume(1.0)
+    if persist:
+        # Keep OS mixer at full while ATC is in use; softvol handles gain.
+        _ensure_system_output_volume(1.0)
     _send_ipc(
         ["set_property", "volume", _mpv_softvol(_effective_atc_ui_volume(value))]
     )


### PR DESCRIPTION
Every settings slider (brightness, HUD opacity, volumes, VFR opacity, lofi, theme channels) and the HUD volume popover canceled an armed drag when the finger drifted ~28 s-px vertically off the row. A thumb sweeping horizontally across the round glass naturally arcs, so the sliders felt finicky — mid-sweep the drag would silently drop and the rest of the gesture scrolled the page instead.

The drag-cancel band widens from s(28) to s(64). A genuine far wander (another region entirely) still cancels, so the sticky-X value-steal guard the band exists for stays intact.

Test in `tests/test_lofi_audio.py` pins the new tolerance and the far-wander cancel.