### PR TITLE
Fix Targets editors: taps, preview icons, layout

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -1876,10 +1876,15 @@ class RoundTouchDisplay:
             self._open_atc_picker("output")
         elif action == "status":
             return
+        elif action in info.TARGETS_EDITOR_KINDS:
+            self._open_atc_picker(action)
 
     def _open_atc_picker(self, kind: str) -> None:
         kind = str(kind or "").strip().lower()
-        if kind not in info.LIST_PICKER_KINDS:
+        if (
+            kind not in info.LIST_PICKER_KINDS
+            and kind not in info.TARGETS_EDITOR_KINDS
+        ):
             return
         if kind == "channel" and not settings.atc_airport():
             return
@@ -1995,6 +2000,22 @@ class RoundTouchDisplay:
         action, value = hit
         if action in ("close", "outside"):
             self._close_atc_picker()
+            return
+        if action == "tgt_swatch":
+            kind = self._atc_picker
+            if kind in info.TARGETS_EDITOR_KINDS:
+                info.targets_apply_swatch(kind, value)
+                radar.invalidate_frame_layer()
+                self._note_activity()
+                self._safe_draw()
+            return
+        if action == "tgt_segment":
+            kind = self._atc_picker
+            if kind in info.TARGETS_EDITOR_KINDS:
+                info.targets_apply_segment(kind, value)
+                radar.invalidate_frame_layer()
+                self._note_activity()
+                self._safe_draw()
             return
         if action == "time_num":
             try:
@@ -4013,6 +4034,7 @@ class RoundTouchDisplay:
                 info.PAGE_LAYERS,
                 info.PAGE_ATC,
                 info.PAGE_ATC_QUIET,
+                info.PAGE_TARGETS,
             )
             and x is not None
             and y is not None

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -746,6 +746,14 @@ _TARGETS_CATEGORY = {
     "tgt_drone": "drone",
     "tgt_vessel": "vessel",
 }
+# Representative flights so the editor preview uses the same icon art and
+# Targets settings bucket as live radar (heli/drone need real ICAO codes).
+_TARGETS_PREVIEW_FLIGHT = {
+    "tgt_plane": {"plane": "B738"},
+    "tgt_heli": {"plane": "R44"},
+    "tgt_drone": {"plane": "JAS4"},
+    "tgt_vessel": {"kind": "vessel", "speed": 12, "stationary": False},
+}
 _TGT_FORM_LABELS = (("icon", "Icon"), ("triangle", "Triangle"), ("dot", "Dot"))
 _TGT_MODE_LABELS = (("letters", "Letters"), ("degrees", "Degrees"), ("both", "Both"))
 
@@ -769,6 +777,26 @@ def _tgt_grid_origin() -> tuple[int, int, int]:
     x0 = theme.CENTER_X - (cols * cell) // 2
     y0 = theme.CENTER_Y - int(theme.VISIBLE_RADIUS * 0.52)
     return x0, y0, cell
+
+
+def _tgt_title_arc_r() -> int:
+    return int(theme.VISIBLE_RADIUS * 0.84)
+
+
+def _tgt_preview_band() -> tuple[int, int]:
+    """Vertical band (top, bottom) for the live glyph under the curved title."""
+    arc_r = _tgt_title_arc_r()
+    title_font = draw.load_font(theme.s(15), bold=True)
+    top = theme.CENTER_Y - arc_r + title_font.get_height() + theme.s(6)
+    _, grid_top, _cell = _tgt_grid_origin()
+    return int(top), int(grid_top)
+
+
+def _tgt_preview_center() -> tuple[int, int]:
+    """Center the preview in the gap between title and crayon grid."""
+    top, grid_top = _tgt_preview_band()
+    cy = (top + grid_top) // 2
+    return theme.CENTER_X, cy
 
 
 def _tgt_slider_rows(kind: str) -> list[str]:
@@ -857,6 +885,93 @@ def targets_editor_slider_drag_band(kind: str, which: str, x: int, y: int) -> bo
     return slider_drag_band_contains(geom[0], y)
 
 
+def _tgt_preview_color(kind: str) -> tuple[int, int, int]:
+    """Accent used for the live glyph preview (Auto → today's default)."""
+    custom = _tgt_editor_color(kind)
+    if kind == "tgt_compass":
+        return custom or theme.GRID
+    if kind == "tgt_blip":
+        return custom or theme.AIRCRAFT
+    if kind in _TARGETS_CATEGORY:
+        cat = _TARGETS_CATEGORY[kind]
+        if cat == "vessel":
+            return custom or theme.VESSEL_MOVING
+        return custom or theme.AIRCRAFT
+    return theme.AIRCRAFT
+
+
+def _draw_targets_compass_preview(
+    surface: pygame.Surface, cx: int, cy: int, color: tuple[int, int, int]
+) -> None:
+    import math as _math
+
+    rose_alpha = int(255 * settings.compass_opacity() / 100)
+    mode = settings.compass_labels()
+    top, grid_top = _tgt_preview_band()
+    card_r = min(theme.s(44), max(theme.s(20), (grid_top - top) // 2 - theme.s(6)))
+    font = draw.load_font(max(theme.s(8), card_r // 4), bold=True)
+    diag_font = draw.load_font(max(theme.s(7), card_r // 5), bold=True)
+
+    def _blit(text_surf: pygame.Surface, center: tuple[int, int]) -> None:
+        if rose_alpha < 255:
+            text_surf = text_surf.copy()
+            text_surf.set_alpha(rose_alpha)
+        surface.blit(text_surf, text_surf.get_rect(center=center))
+
+    if mode in ("letters", "both"):
+        for text, bearing in (("N", 0), ("E", 90), ("S", 180), ("W", 270)):
+            rad = _math.radians(bearing - 90)
+            x = cx + int(card_r * _math.cos(rad))
+            y = cy + int(card_r * _math.sin(rad))
+            _blit(font.render(text, True, color), (x, y))
+    if mode in ("degrees", "both"):
+        for bearing in range(0, 360, 30):
+            if mode == "both" and bearing % 90 == 0:
+                continue
+            rad = _math.radians(bearing - 90)
+            x = cx + int(card_r * _math.cos(rad))
+            y = cy + int(card_r * _math.sin(rad))
+            _blit(diag_font.render(f"{bearing:03d}", True, color), (x, y))
+
+
+def _draw_targets_blip_preview(
+    surface: pygame.Surface, cx: int, cy: int, color: tuple[int, int, int]
+) -> None:
+    r = max(
+        2,
+        int(round(theme.RIM_BLIP_RADIUS * settings.blip_size_pct() / 100.0)),
+    )
+    alpha = settings.blip_opacity()
+    if alpha >= 100:
+        pygame.draw.circle(surface, color, (cx, cy), r)
+        return
+    dot = pygame.Surface((r * 2, r * 2), pygame.SRCALPHA)
+    pygame.draw.circle(
+        dot, (*color[:3], int(255 * alpha / 100)), (r, r), r,
+    )
+    surface.blit(dot, (cx - r, cy - r))
+
+
+def _draw_targets_editor_preview(surface: pygame.Surface, kind: str) -> None:
+    """Live glyph under the curved title — mirrors radar rendering."""
+    cx, cy = _tgt_preview_center()
+    color = _tgt_preview_color(kind)
+    if kind == "tgt_compass":
+        _draw_targets_compass_preview(surface, cx, cy, color)
+        return
+    if kind == "tgt_blip":
+        _draw_targets_blip_preview(surface, cx, cy, color)
+        return
+    flight = _TARGETS_PREVIEW_FLIGHT.get(kind)
+    if not flight:
+        return
+    from display.round_touch import aircraft
+
+    aircraft.draw_plane_icon(
+        surface, cx, cy, 45.0, color, compact=True, flight=flight,
+    )
+
+
 def _draw_targets_editor(surface, kind: str) -> int:
     """Modal editor for one Targets section; registers picker-style hits."""
     global _atc_picker_hits, _atc_picker_list_rect
@@ -873,7 +988,7 @@ def _draw_targets_editor(surface, kind: str) -> int:
     small_font = draw.load_font(theme.s(11), bold=True)
 
     # Curved title.
-    arc_r = int(theme.VISIBLE_RADIUS * 0.84)
+    arc_r = _tgt_title_arc_r()
     title_items = [
         title_font.render(ch, True, theme.LABEL)
         for ch in _TARGETS_TITLES.get(kind, "Targets")
@@ -882,6 +997,8 @@ def _draw_targets_editor(surface, kind: str) -> int:
         surface, title_items, r=arc_r, mid=-_math.pi / 2, bottom=False,
         cx=theme.CENTER_X, cy=theme.CENTER_Y,
     )
+
+    _draw_targets_editor_preview(surface, kind)
 
     # Swatch grid: Auto cell + the crayon palette.
     current = _tgt_editor_color(kind)

--- a/flightscnr/tests/test_targets_page.py
+++ b/flightscnr/tests/test_targets_page.py
@@ -93,6 +93,17 @@ class TestTargetsPage:
         assert len(labels) == len(info.TARGETS_ACTIONS)
         assert any("Compass" in t for t in labels)
 
+    def test_row_tap_opens_editor(self):
+        from display.round_touch import app as app_mod
+
+        opened = []
+        d = object.__new__(app_mod.RoundTouchDisplay)
+        d._open_atc_picker = lambda kind: opened.append(kind)
+        d._display_focus = -1
+        row = info.TARGETS_ACTIONS.index("tgt_plane")
+        d._apply_display_row(info.PAGE_TARGETS, row)
+        assert opened == ["tgt_plane"]
+
     def test_page_order(self):
         assert info.PAGE_TARGETS == info.PAGE_COLORS + 1
         assert info.PAGE_SYSTEM == info.PAGE_TARGETS + 1
@@ -155,6 +166,31 @@ class TestTargetsEditor:
         assert settings.compass_opacity() == 55
         info.targets_apply_slider("tgt_blip", "size", 100, persist=False)
         info.targets_apply_slider("tgt_compass", "opacity", 100, persist=False)
+
+
+class TestTargetsPreview:
+    def test_preview_flights_match_categories(self):
+        for kind, cat in info._TARGETS_CATEGORY.items():
+            flight = info._TARGETS_PREVIEW_FLIGHT[kind]
+            assert aircraft.target_category(flight) == cat
+
+    def test_preview_color_auto_defaults(self):
+        settings.set_target_color("heli", None)
+        assert info._tgt_preview_color("tgt_heli") == theme.AIRCRAFT
+        settings.set_compass_color(None)
+        assert info._tgt_preview_color("tgt_compass") == theme.GRID
+
+    def test_preview_center_sits_above_crayon_grid(self):
+        _top, grid_top = info._tgt_preview_band()
+        _cx, cy = info._tgt_preview_center()
+        assert _top < cy < grid_top
+
+    def test_preview_draws_without_error(self):
+        if not pygame.font.get_init():
+            return
+        surface = pygame.Surface((theme.SIZE, theme.SIZE))
+        for kind in info.TARGETS_ACTIONS:
+            info._draw_targets_editor_preview(surface, kind)
 
 
 class TestDrawForms:


### PR DESCRIPTION
## Summary
- Wire Targets row taps to open category editors
- Add live preview glyphs (plane/heli/drone/vessel/compass/blip)
- Position preview between curved title and crayon grid