### PR TITLE
Portal Targets section

### DIFF
--- a/flightscnr/tests/test_targets_page.py
+++ b/flightscnr/tests/test_targets_page.py
@@ -204,3 +204,48 @@ class TestDrawForms:
         aircraft.draw_plane_icon(surface, 100, 100, 0, (255, 0, 0), flight={"plane": "B738"})
         assert surface.get_at((100, 92))[:3] == (255, 0, 0)
         settings.set_target_form("plane", "icon")
+
+
+class TestTargetsWeb:
+    @staticmethod
+    def _client():
+        from web import app as web_app
+
+        return web_app.app.test_client()
+
+    def test_json_and_save_round_trip(self, monkeypatch):
+        from web import app as web_app
+
+        monkeypatch.setattr(web_app, "_wifi_portal_active", lambda: False)
+        client = self._client()
+        r = client.get("/targets/json")
+        assert r.status_code == 200
+        body = r.get_json()
+        assert set(body["categories"]) == set(settings.TARGET_CATEGORIES)
+        r = client.post("/targets", json={
+            "categories": {"plane": {"color": "#00ffff", "size": 120, "form": "dot"}},
+            "compass": {"labels": "both", "opacity": 60},
+            "blip": {"color": "", "size": 80},
+        })
+        assert r.status_code == 200
+        assert settings.target_color("plane") == (0, 255, 255)
+        assert settings.target_size_pct("plane") == 120
+        assert settings.target_form("plane") == "dot"
+        assert settings.compass_labels() == "both"
+        assert settings.compass_opacity() == 60
+        assert settings.blip_color() is None
+        assert settings.blip_size_pct() == 80
+        client.post("/targets", json={
+            "categories": {"plane": {"color": "", "size": 100, "form": "icon"}},
+            "compass": {"labels": "letters", "opacity": 100},
+            "blip": {"size": 100},
+        })
+
+    def test_index_ships_targets_section(self, monkeypatch):
+        from web import app as web_app
+
+        monkeypatch.setattr(web_app, "_wifi_portal_active", lambda: False)
+        client = self._client()
+        html = client.get("/").get_data(as_text=True)
+        assert 'id="targets_body"' in html
+        assert 'id="btn-targets"' in html

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -1033,6 +1033,89 @@ def display_save():
     )
 
 
+@app.get("/targets/json")
+def targets_json():
+    from display.round_touch import settings
+
+    def _hex(rgb):
+        return "#%02x%02x%02x" % tuple(rgb) if rgb else ""
+
+    return jsonify(
+        {
+            "categories": {
+                cat: {
+                    "color": _hex(settings.target_color(cat)),
+                    "size": settings.target_size_pct(cat),
+                    "form": settings.target_form(cat),
+                }
+                for cat in settings.TARGET_CATEGORIES
+            },
+            "compass": {
+                "color": _hex(settings.compass_color()),
+                "opacity": settings.compass_opacity(),
+                "labels": settings.compass_labels(),
+            },
+            "blip": {
+                "color": _hex(settings.blip_color()),
+                "size": settings.blip_size_pct(),
+                "opacity": settings.blip_opacity(),
+            },
+        }
+    )
+
+
+@app.post("/targets")
+def targets_save():
+    from display.round_touch import settings
+
+    def _rgb(raw):
+        raw = str(raw or "").strip().lstrip("#")
+        if len(raw) != 6:
+            return None
+        try:
+            return tuple(int(raw[i : i + 2], 16) for i in (0, 2, 4))
+        except ValueError:
+            return None
+
+    data = request.get_json(silent=True) or {}
+    cats = data.get("categories") or {}
+    for cat in settings.TARGET_CATEGORIES:
+        entry = cats.get(cat) or {}
+        if "color" in entry:
+            settings.set_target_color(cat, _rgb(entry.get("color")))
+        if "size" in entry:
+            try:
+                settings.set_target_size_pct(cat, int(entry.get("size")))
+            except (TypeError, ValueError):
+                pass
+        if "form" in entry:
+            settings.set_target_form(cat, str(entry.get("form") or ""))
+    compass = data.get("compass") or {}
+    if "color" in compass:
+        settings.set_compass_color(_rgb(compass.get("color")))
+    if "opacity" in compass:
+        try:
+            settings.set_compass_opacity(int(compass.get("opacity")))
+        except (TypeError, ValueError):
+            pass
+    if "labels" in compass:
+        settings.set_compass_labels(str(compass.get("labels") or ""))
+    blip = data.get("blip") or {}
+    if "color" in blip:
+        settings.set_blip_color(_rgb(blip.get("color")))
+    if "size" in blip:
+        try:
+            settings.set_blip_size_pct(int(blip.get("size")))
+        except (TypeError, ValueError):
+            pass
+    if "opacity" in blip:
+        try:
+            settings.set_blip_opacity(int(blip.get("opacity")))
+        except (TypeError, ValueError):
+            pass
+    return jsonify({"ok": True})
+
+
 @app.get("/lofi/tracks")
 def lofi_tracks():
     from display.round_touch import settings

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -736,6 +736,16 @@
     </details>
 
     <details class="card">
+        <summary><span class="ico">&#9678;</span>Targets<span class="sum">colors, sizes, symbols</span><span class="chev">&#9656;</span></summary>
+        <div class="body">
+            <p class="hint">Per-category visibility for the radar: accent color, size, and symbol for planes, helicopters, drones, and vessels, plus compass rose and blip styling. Same as Settings &rarr; Targets on the device. Auto keeps today's default look.</p>
+            <div id="targets_body"></div>
+            <button class="btn btn-primary" id="btn-targets" type="button" style="margin-top:.7rem">Save targets</button>
+            <div id="targets-status" class="status"></div>
+        </div>
+    </details>
+
+    <details class="card">
         <summary><span class="ico">&#9729;</span>Weather<span class="sum">units</span><span class="chev">&#9656;</span></summary>
         <div class="body">
             <label for="weather_units">Units</label>
@@ -3620,6 +3630,119 @@ document.addEventListener("DOMContentLoaded", () => {
         inp.addEventListener("focus", () => { if (inp.value.trim()) render(inp.value); });
         document.addEventListener("click", (ev) => {
             if (!ev.target.closest(".search-wrap")) box.classList.add("hidden");
+        });
+    })();
+
+    // --- Targets section: per-category visibility ---
+    (function () {
+        const body = $("targets_body");
+        if (!body) return;
+        const CATS = [
+            ["plane", "Planes"], ["heli", "Helicopters"],
+            ["drone", "Drones"], ["vessel", "Vessels"],
+        ];
+        const FORMS = [["icon", "Icon"], ["triangle", "Triangle"], ["dot", "Dot"]];
+        const MODES = [["letters", "Letters"], ["degrees", "Degrees"], ["both", "Both"]];
+        function colorRow(id) {
+            return '<div class="chk"><label for="' + id + '_auto">Auto color</label>' +
+                '<span class="switch"><input id="' + id + '_auto" type="checkbox" checked><span class="track"></span></span></div>' +
+                '<label for="' + id + '_color">Custom color</label>' +
+                '<input id="' + id + '_color" type="color" value="#00ff00">';
+        }
+        function rangeRow(id, label, lo, hi, val) {
+            return '<label for="' + id + '">' + label + ' <span id="' + id + '_label">' + val + '%</span></label>' +
+                '<input id="' + id + '" type="range" min="' + lo + '" max="' + hi + '" step="5" value="' + val + '" ' +
+                'oninput="document.getElementById(\'' + id + '_label\').textContent = this.value + \'%\'">';
+        }
+        function selectRow(id, label, options) {
+            let opts = options.map(([v, t]) => '<option value="' + v + '">' + t + "</option>").join("");
+            return '<label for="' + id + '">' + label + "</label><select id=\"" + id + '">' + opts + "</select>";
+        }
+        let html = "";
+        for (const [cat, title] of CATS) {
+            html += '<p style="margin:.9rem 0 .2rem;font-weight:600">' + title + "</p>";
+            html += colorRow("tgt_" + cat);
+            html += rangeRow("tgt_" + cat + "_size", "Size", 50, 150, 100);
+            html += selectRow("tgt_" + cat + "_form", "Symbol", FORMS);
+        }
+        html += '<p style="margin:.9rem 0 .2rem;font-weight:600">Compass rose</p>';
+        html += colorRow("tgt_compass");
+        html += rangeRow("tgt_compass_opacity", "Opacity", 20, 100, 100);
+        html += selectRow("tgt_compass_labels", "Labels", MODES);
+        html += '<p style="margin:.9rem 0 .2rem;font-weight:600">Blips</p>';
+        html += colorRow("tgt_blip");
+        html += rangeRow("tgt_blip_size", "Size", 50, 150, 100);
+        html += rangeRow("tgt_blip_opacity", "Opacity", 20, 100, 100);
+        body.innerHTML = html;
+
+        function setColor(id, hex) {
+            const auto = $(id + "_auto"), color = $(id + "_color");
+            if (auto) auto.checked = !hex;
+            if (color && hex) color.value = hex;
+        }
+        function getColor(id) {
+            const auto = $(id + "_auto"), color = $(id + "_color");
+            if (auto && auto.checked) return "";
+            return color ? color.value : "";
+        }
+        function setRange(id, v) {
+            const el = $(id);
+            if (!el) return;
+            el.value = String(v);
+            const lab = $(id + "_label");
+            if (lab) lab.textContent = v + "%";
+        }
+        async function load() {
+            try {
+                const d = await jsonFetch("/targets/json");
+                for (const [cat] of CATS) {
+                    const c = (d.categories || {})[cat] || {};
+                    setColor("tgt_" + cat, c.color || "");
+                    setRange("tgt_" + cat + "_size", c.size ?? 100);
+                    if ($("tgt_" + cat + "_form")) $("tgt_" + cat + "_form").value = c.form || "icon";
+                }
+                const cp = d.compass || {};
+                setColor("tgt_compass", cp.color || "");
+                setRange("tgt_compass_opacity", cp.opacity ?? 100);
+                if ($("tgt_compass_labels")) $("tgt_compass_labels").value = cp.labels || "letters";
+                const bl = d.blip || {};
+                setColor("tgt_blip", bl.color || "");
+                setRange("tgt_blip_size", bl.size ?? 100);
+                setRange("tgt_blip_opacity", bl.opacity ?? 100);
+            } catch (_) {}
+        }
+        load();
+        const btn = $("btn-targets");
+        if (btn) btn.addEventListener("click", async () => {
+            const payload = {categories: {}, compass: {}, blip: {}};
+            for (const [cat] of CATS) {
+                payload.categories[cat] = {
+                    color: getColor("tgt_" + cat),
+                    size: Number($("tgt_" + cat + "_size").value),
+                    form: $("tgt_" + cat + "_form").value,
+                };
+            }
+            payload.compass = {
+                color: getColor("tgt_compass"),
+                opacity: Number($("tgt_compass_opacity").value),
+                labels: $("tgt_compass_labels").value,
+            };
+            payload.blip = {
+                color: getColor("tgt_blip"),
+                size: Number($("tgt_blip_size").value),
+                opacity: Number($("tgt_blip_opacity").value),
+            };
+            const st = $("targets-status");
+            try {
+                await jsonFetch("/targets", {
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify(payload),
+                });
+                if (st) st.textContent = "Saved.";
+            } catch (_) {
+                if (st) st.textContent = "Save failed.";
+            }
         });
     })();
 </script>


### PR DESCRIPTION
## Summary
- Add web portal Targets accordion (planes/heli/drone/vessel, compass rose, blips)
- `GET /targets/json` and `POST /targets` backed by shared display settings
- Portal JSON round-trip tests

Device-side Targets editors already shipped in #179/#180; this is the portal parity half cherry-picked from PR #176.

## Test plan
- [ ] Portal shows Targets section with color/size/symbol controls
- [ ] Saving from portal updates device radar after settings reload
- [ ] `cd flightscnr && python3 -m pytest tests/test_targets_page.py -q`

Made with [Cursor](https://cursor.com)