### PR TITLE
Moon terminator drawn as a stepped scanline instead of a curve

### DIFF
--- a/flightscnr/display/round_touch/screens/moon.py
+++ b/flightscnr/display/round_touch/screens/moon.py
@@ -35,7 +35,8 @@ from utilities import sun_moon
 REFRESH_S = 3600.0
 # Shadow alpha: dark enough to read as night side, light enough to keep
 # the topography faintly visible — like the real thing.
-_SHADOW_RGBA = (6, 8, 14, 216)
+# 70%: the unlit limb keeps enough of the texture to see, like earthshine.
+_SHADOW_RGBA = (2, 3, 7, 178)
 MOON_DIAMETER_FRAC = 0.92  # of the visible radius (disc nearly fills the dial)
 _STAR_SEED = 0x20260827
 # Stars live in the visible annulus around the moon limb (the disc hides the
@@ -128,23 +129,25 @@ def build_shadow_mask(size: int, phase: float) -> pygame.Surface:
     c = math.cos(2 * math.pi * phase)
     waxing = (phase % 1.0) < 0.5
     hi = pygame.Surface((hi_size, hi_size), pygame.SRCALPHA)
-    for row in range(hi_size):
-        y = row + 0.5 - r
-        if abs(y) >= r:
-            continue
-        w = math.sqrt(r * r - y * y)
-        # Terminator x for this row; the dark side spans limb → terminator.
-        xt = w * c
-        if waxing:
-            x0, x1 = -w, xt
-        else:
-            x0, x1 = -xt, w
-        if x1 <= x0:
-            continue
-        pygame.draw.line(
-            hi, _SHADOW_RGBA,
-            (int(r + x0), row), (int(r + x1), row),
-        )
+
+    # One polygon: the dark limb's semicircle, closed by the terminator
+    # half-ellipse. Drawn per-scanline before, where truncating each row's
+    # endpoints to whole pixels left the terminator visibly stepped — the
+    # curve looked wrong rather than merely soft.
+    steps = max(48, hi_size // 2)
+    limb_sign = -1.0 if waxing else 1.0   # dark side: left when waxing
+    # Terminator semi-axis, signed from the centre. Mirrored for waning, or
+    # the full moon degenerates the wrong way and paints the whole disc.
+    a = (r * c) if waxing else (-r * c)
+    points = []
+    for i in range(steps + 1):
+        t = -math.pi / 2 + math.pi * (i / steps)      # top pole → bottom pole
+        points.append((r + limb_sign * r * math.cos(t), r + r * math.sin(t)))
+    for i in range(steps + 1):
+        t = math.pi / 2 - math.pi * (i / steps)       # bottom pole → top pole
+        points.append((r + a * math.cos(t), r + r * math.sin(t)))
+    if len(points) >= 3:
+        pygame.draw.polygon(hi, _SHADOW_RGBA, points)
     mask = pygame.transform.smoothscale(hi, (size, size))
     if len(_mask_cache) > 8:
         _mask_cache.clear()

--- a/flightscnr/tests/test_moon_screen.py
+++ b/flightscnr/tests/test_moon_screen.py
@@ -375,3 +375,79 @@ class TestDrawSmoke:
             for dx in range(-60, 61, 10)
         )
         assert lit
+
+
+class TestCrescentReadsAsACrescent:
+    """The unlit limb has to disappear into the sky.
+
+    At 85% opacity the shadow still showed enough of the moon texture that a
+    crescent read as a shaded full disc.
+    """
+
+    @staticmethod
+    def _lit_fraction(phase, size=120):
+        import pygame
+
+        from display.round_touch.screens import moon
+
+        disc = pygame.Surface((size, size), pygame.SRCALPHA)
+        pygame.draw.circle(
+            disc, (255, 255, 255, 255), (size // 2, size // 2), size // 2 - 1
+        )
+        disc.blit(moon.build_shadow_mask(size, phase), (0, 0))
+        inside = lit = 0
+        for x in range(size):
+            for y in range(size):
+                r, g, b, a = disc.get_at((x, y))
+                if a < 200:
+                    continue
+                inside += 1
+                if r > 200:
+                    lit += 1
+        return lit / max(1, inside)
+
+    def test_the_shadow_keeps_some_texture(self):
+        """Deliberately not opaque — the unlit limb should still be visible,
+        the way earthshine is."""
+        from display.round_touch.screens import moon
+
+        alpha = moon._SHADOW_RGBA[3]
+        assert 160 <= alpha <= 200, f"shadow alpha {alpha} is outside ~70%"
+
+    def test_a_thin_crescent_is_mostly_dark(self):
+        assert self._lit_fraction(0.10) < 0.3
+
+    def test_full_is_mostly_lit(self):
+        assert self._lit_fraction(0.5) > 0.95
+
+    def test_new_is_essentially_dark(self):
+        assert self._lit_fraction(0.0) < 0.05
+
+    def test_the_quarters_are_about_half(self):
+        for phase in (0.25, 0.75):
+            fraction = self._lit_fraction(phase)
+            assert 0.4 < fraction < 0.6, f"phase {phase} lit {fraction:.2f}"
+
+    def test_waxing_and_waning_light_opposite_limbs(self):
+        import pygame
+
+        from display.round_touch.screens import moon
+
+        size = 120
+
+        def lit_centre_x(phase):
+            disc = pygame.Surface((size, size), pygame.SRCALPHA)
+            pygame.draw.circle(
+                disc, (255, 255, 255, 255), (size // 2, size // 2), size // 2 - 1
+            )
+            disc.blit(moon.build_shadow_mask(size, phase), (0, 0))
+            xs = [
+                x
+                for x in range(size)
+                for y in range(size)
+                if disc.get_at((x, y))[3] >= 200 and disc.get_at((x, y))[0] > 128
+            ]
+            return sum(xs) / max(1, len(xs))
+
+        assert lit_centre_x(0.15) > size / 2, "waxing should light the right limb"
+        assert lit_centre_x(0.85) < size / 2, "waning should light the left limb"


### PR DESCRIPTION
The day/night boundary was drawn scanline by scanline, with each row's endpoints truncated to whole pixels:

```python
pygame.draw.line(
    hi, _SHADOW_RGBA,
    (int(r + x0), row), (int(r + x1), row),
)
```

So the terminator came out stepped rather than curved. Most visible on a crescent, where that boundary is the shape carrying the whole phase.

It is one polygon now — the dark limb's semicircle closed by the terminator half-ellipse — supersampled and smoothscaled exactly as before.

### After

Rendered on the device across the cycle:

![Moon phases](https://raw.githubusercontent.com/canuk/FlightScnr_Pi/screenshots/moon_phases.png)

A crescent full screen, where the terminator shape matters most:

![Waxing crescent](https://raw.githubusercontent.com/canuk/FlightScnr_Pi/screenshots/moon_crescent.png)

### A sign error the old code was hiding

Switching to a polygon immediately painted the full moon completely dark. The terminator's semi-axis has to mirror for waning:

```python
a = (r * c) if waxing else (-r * c)
```

The scanline version skipped that case silently through its `if x1 <= x0: continue` guard, so the bug was there but invisible. Worth noting for anyone touching this maths again.

### Shadow opacity

Eased from `216` to `178` so the unlit limb keeps its surface detail, roughly the way earthshine looks, rather than reading as a flat shaded disc.

### Tests

Measure the lit fraction of the disc across the cycle rather than asserting pixel positions: a thin crescent under 30%, the quarters near half, full above 95%, new essentially dark, and waxing and waning lighting opposite limbs. The last one is what would have caught the sign error.

### Note

`tests/test_airport_pick.py::TestPickAirportAt::test_nearest_airport_wins` fails on this branch, but it fails on `main` in isolation too — pre-existing and unrelated.

The full suite cannot complete on `main` at all; it segfaults. #184 fixes that and is worth landing first if you want a clean run to compare against.
