### PR TITLE
Lofi tile: no METAR stack, pause skip, stamp key

### DIFF
--- a/flightscnr/display/round_touch/airport_tile.py
+++ b/flightscnr/display/round_touch/airport_tile.py
@@ -92,6 +92,9 @@ def open_tile(airport: dict) -> None:
     if _airport is not None and str(_airport.get("ident") or "").upper() == ident:
         dismiss()
         return
+    import display.round_touch.lofi_tile as lofi_tile
+
+    lofi_tile.dismiss()
     _airport = dict(airport)
     _metar = None
     _fetch_done = False

--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -4454,23 +4454,32 @@ class RoundTouchDisplay:
                             zoom_action := zoom_buttons.hit_button(tap[0], tap[1])
                         ) is not None:
                             self._apply_zoom_button(zoom_action)
-                        elif lofi_tile.is_open():
-                            # While the tile is up it owns the tap: a button
-                            # on it, or anywhere else to dismiss.
-                            button = lofi_tile.hit_button(tap[0], tap[1])
-                            if button is not None:
-                                lofi_tile.apply(button)
-                            else:
-                                lofi_tile.dismiss()
+                        elif (
+                            lofi_btn := (
+                                lofi_tile.hit_button(tap[0], tap[1])
+                                if lofi_tile.is_open()
+                                else None
+                            )
+                        ) is not None:
+                            lofi_tile.apply(lofi_btn)
+                            self._safe_draw()
+                        elif lofi_tile.is_open() and lofi_tile.hit(tap[0], tap[1]):
+                            # Tap on the panel chrome, not a button: dismiss.
+                            lofi_tile.dismiss()
                             self._safe_draw()
                         elif (
                             lofi_action := lofi_controls.hit_button(tap[0], tap[1])
                         ) is not None:
+                            if lofi_tile.is_open():
+                                lofi_tile.dismiss()
                             self._apply_lofi_skip(lofi_action)
                         elif lofi_controls.hit_title(tap[0], tap[1]):
                             lofi_tile.open_tile()
                             self._safe_draw()
                         elif self._open_flight_or_fire_at(tap[0], tap[1]):
+                            self._safe_draw()
+                        elif lofi_tile.is_open():
+                            lofi_tile.dismiss()
                             self._safe_draw()
         elif tap and self.screen == SCREEN_FLIGHT:
             # Any tap (content or footer) restarts the idle countdown.
@@ -5258,6 +5267,7 @@ class RoundTouchDisplay:
         if airport is not None:
             from display.round_touch import airport_tile
 
+            lofi_tile.dismiss()
             airport_tile.open_tile(airport)
             radar.invalidate_frame_layer()
             self._note_activity()
@@ -5283,6 +5293,7 @@ class RoundTouchDisplay:
         try:
             from display.round_touch import airport_tile
 
+            lofi_tile.dismiss()
             airport_tile.open_tile(airport)
         except ImportError:
             # METAR tile not merged here — fall back to the callout toast.

--- a/flightscnr/display/round_touch/lofi_tile.py
+++ b/flightscnr/display/round_touch/lofi_tile.py
@@ -67,6 +67,9 @@ def open_tile(track_name: str | None = None) -> None:
         _track = ""
     _open = True
     _opened_at = time.monotonic()
+    import display.round_touch.airport_tile as airport_tile
+
+    airport_tile.dismiss()
 
 
 def blocked_reason() -> str | None:
@@ -153,7 +156,7 @@ def stamp_key():
     """What the drawn tile depends on, so a stamp can be cached per frame."""
     from utilities import lofi_audio
 
-    return (_track, lofi_audio.is_paused())
+    return (_track, lofi_audio.is_paused(), lofi_audio.playback_block())
 
 
 def display_name(filename: str | None) -> str:

--- a/flightscnr/display/round_touch/rotation.py
+++ b/flightscnr/display/round_touch/rotation.py
@@ -720,6 +720,13 @@ def _blit_lofi_tile(
         return None
     if not lofi_tile.is_open():
         return None
+    try:
+        from display.round_touch import airport_tile
+
+        if airport_tile.is_open():
+            return None
+    except ImportError:
+        pass
 
     global _lofi_tile_stamp, _lofi_tile_stamp_key
     key = (lofi_tile.stamp_key(), rotation, theme.SIZE)

--- a/flightscnr/tests/test_lofi_pause_disable.py
+++ b/flightscnr/tests/test_lofi_pause_disable.py
@@ -232,6 +232,22 @@ class TestDisablingATrack:
         lofi_audio.disable_track("a.mp3", skip=True)
         assert skipped == [1], "the disabled track kept playing"
 
+    def test_skip_while_paused_clears_the_hold(self, monkeypatch):
+        skipped = []
+        monkeypatch.setattr(lofi_audio, "next_track", lambda: skipped.append(1))
+        lofi_audio.pause()
+        lofi_audio.disable_track("a.mp3", skip=True)
+        assert skipped == [1]
+        assert lofi_audio.is_paused() is False
+
+    def test_skip_false_does_not_resume(self, monkeypatch):
+        skipped = []
+        monkeypatch.setattr(lofi_audio, "next_track", lambda: skipped.append(1))
+        lofi_audio.pause()
+        lofi_audio.disable_track("a.mp3", skip=False)
+        assert skipped == []
+        assert lofi_audio.is_paused() is True
+
     def test_it_does_not_skip_when_not_asked(self, monkeypatch):
         skipped = []
         monkeypatch.setattr(lofi_audio, "next_track", lambda: skipped.append(1))

--- a/flightscnr/tests/test_lofi_tile.py
+++ b/flightscnr/tests/test_lofi_tile.py
@@ -267,6 +267,12 @@ class TestWiring:
         source = inspect.getsource(app_mod.RoundTouchDisplay._handle_navigation)
         assert "lofi_controls.hit_title" in source
         assert "lofi_tile.open_tile" in source
+        # Title / airport taps must run even when the other overlay is up.
+        # Owning every tap while the tile is open only dismissed METAR (or
+        # lofi) and never opened the one the finger was on.
+        assert source.find("lofi_controls.hit_title") < source.find(
+            "_open_flight_or_fire_at"
+        )
 
     def test_the_radar_screen_does_not_paint_it_to_the_draw_surface(self):
         """That surface is not what the radar presents. See TestItReachesThePanel."""
@@ -556,3 +562,72 @@ class TestWhyTheBedIsHeld:
 
         monkeypatch.setattr(settings, "lofi_enabled", lambda: False)
         assert _REAL_PLAYBACK_BLOCK()
+
+
+class TestStampKey:
+    def test_it_includes_the_block_reason(self, monkeypatch):
+        lofi_tile.open_tile()
+        monkeypatch.setattr(lofi_audio, "is_paused", lambda: False)
+        monkeypatch.setattr(lofi_audio, "playback_block", lambda: None)
+        playing = lofi_tile.stamp_key()
+        monkeypatch.setattr(lofi_audio, "playback_block", lambda: "Quiet hours")
+        blocked = lofi_tile.stamp_key()
+        assert playing != blocked
+        assert blocked[2] == "Quiet hours"
+
+
+class TestItDoesNotStackWithMetar:
+    def test_opening_lofi_closes_the_airport_tile(self, monkeypatch):
+        from display.round_touch import airport_tile
+
+        airport_tile._reset_for_tests()
+        monkeypatch.setattr(airport_tile, "_start_fetch", lambda ident: None)
+        airport_tile.open_tile({"ident": "KSAN", "name": "San Diego"})
+        assert airport_tile.is_open()
+        lofi_tile.open_tile()
+        assert lofi_tile.is_open()
+        assert not airport_tile.is_open()
+        airport_tile._reset_for_tests()
+
+    def test_opening_airport_closes_the_lofi_tile(self, monkeypatch):
+        from display.round_touch import airport_tile
+
+        airport_tile._reset_for_tests()
+        monkeypatch.setattr(airport_tile, "_start_fetch", lambda ident: None)
+        lofi_tile.open_tile()
+        assert lofi_tile.is_open()
+        airport_tile.open_tile({"ident": "KSAN", "name": "San Diego"})
+        assert airport_tile.is_open()
+        assert not lofi_tile.is_open()
+        airport_tile._reset_for_tests()
+
+    def test_the_stamp_does_not_draw_lofi_over_metar(self, monkeypatch):
+        """Even if both flags were set, METAR is the one overlay on screen."""
+        from display.round_touch import airport_tile, theme
+
+        airport_tile._reset_for_tests()
+        monkeypatch.setattr(airport_tile, "_start_fetch", lambda ident: None)
+        lofi_tile.open_tile()
+        airport_tile._airport = {"ident": "KSAN"}
+        display = pygame.Surface((theme.SIZE, theme.SIZE))
+        assert _real_rotation()._blit_lofi_tile(display, (0, 0), 0) is None
+        airport_tile._reset_for_tests()
+
+    def test_closing_lofi_does_not_dismiss_the_airport_tile(self, monkeypatch):
+        """A second title tap only closes lofi; METAR must stay if it was up."""
+        from display.round_touch import airport_tile
+
+        calls = []
+        real = airport_tile.dismiss
+
+        def spy():
+            calls.append(1)
+            real()
+
+        monkeypatch.setattr(airport_tile, "dismiss", spy)
+        lofi_tile.open_tile()
+        assert lofi_tile.is_open()
+        n = len(calls)
+        lofi_tile.open_tile()
+        assert not lofi_tile.is_open()
+        assert len(calls) == n

--- a/flightscnr/utilities/lofi_audio.py
+++ b/flightscnr/utilities/lofi_audio.py
@@ -728,6 +728,10 @@ def disable_track(name, *, skip: bool = False) -> None:
         logger.debug("[Lofi] disable failed", exc_info=True)
         return
     if skip:
+        # Skip starts the next file. Leaving the hold set would freeze
+        # tick() so that track never crossfades, with Play still showing.
+        if is_paused():
+            resume()
         next_track()
 
 


### PR DESCRIPTION
## Summary
- Opening METAR dismisses the lofi tile (and the reverse); the stamp will not draw both
- Taps fall through so a METAR pick actually opens instead of only closing lofi
- NEVER PLAY while paused resumes before skip
- Stamp cache includes the playback block reason