### PR TITLE
Portal toggle for automatic Wi-Fi setup hotspot (#127)

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -663,6 +663,27 @@ class RoundTouchDisplay:
 
         Thread(target=_worker, name="wifi-try-saved", daemon=True).start()
 
+    def _tick_wifi_enter_request(self) -> None:
+        """Honor portal/settings cross-process request to open Wi-Fi setup."""
+        if not self._session_unlocked:
+            return
+        if self._wifi_setup_mode or self.screen == SCREEN_WIFI_SETUP:
+            try:
+                wifi_setup_util.clear_enter_wifi_setup_request()
+            except Exception:
+                pass
+            return
+        if self.screen == SCREEN_DISCLAIMER:
+            return
+        try:
+            want = wifi_setup_util.consume_enter_wifi_setup_request()
+        except Exception:
+            logger.debug("Wi-Fi enter-request poll failed", exc_info=True)
+            return
+        if want:
+            self._enter_wifi_setup(reason="manual")
+            self._safe_draw()
+
     def _tick_wifi_link(self) -> None:
         """If client Wi-Fi/ethernet stays down, reopen the setup hotspot after a grace."""
         if (
@@ -671,7 +692,10 @@ class RoundTouchDisplay:
             or self.screen in (SCREEN_WIFI_SETUP, SCREEN_DISCLAIMER)
         ):
             return
-        if wifi_setup_util.skip_requested():
+        if (
+            not wifi_setup_util.auto_hotspot_enabled()
+            and not wifi_setup_util.force_requested()
+        ):
             self._wifi_offline_since = None
             self._wifi_down_streak = 0
             return
@@ -4203,7 +4227,15 @@ class RoundTouchDisplay:
                 self._execute_system_action(action)
 
     def _execute_system_action(self, action: str):
-        """Run reboot / shutdown / app restart after confirmation."""
+        """Run reboot / shutdown / app restart / Wi-Fi setup after confirmation."""
+        if action == "wifi_setup":
+            if wifi_setup_util.skip_requested():
+                logger.info("Start Wi-Fi setup ignored — FLIGHTSCNR_SKIP_WIFI_SETUP set")
+                return
+            self._enter_wifi_setup(reason="manual-settings")
+            self._safe_draw()
+            return
+
         from utilities import system_control
 
         if action == "reboot":
@@ -5925,6 +5957,7 @@ class RoundTouchDisplay:
 
                 # Re-open captive setup if known Wi-Fi stays down past the grace window.
                 self._tick_wifi_link()
+                self._tick_wifi_enter_request()
 
                 if self._fatal_error:
                     # Don't freeze forever during Wi-Fi setup if a draw glitch set fatal

--- a/flightscnr/display/round_touch/screens/info.py
+++ b/flightscnr/display/round_touch/screens/info.py
@@ -168,6 +168,7 @@ ATC_QUIET_ACTIONS = (
 )
 # Power / service controls (portal System section equivalent).
 SYSTEM_ACTIONS = (
+    "wifi_setup",
     "restart",
     "reboot",
     "shutdown",
@@ -1510,6 +1511,8 @@ def atc_picker_list_rect() -> pygame.Rect | None:
 
 
 def _system_button_label(action: str) -> str:
+    if action == "wifi_setup":
+        return "Start Wi-Fi Setup"
     if action == "restart":
         return "Restart App"
     if action == "reboot":

--- a/flightscnr/display/round_touch/settings.py
+++ b/flightscnr/display/round_touch/settings.py
@@ -469,6 +469,9 @@ _defaults = {
     # Safety disclaimer "Don't show again" version (0 = not remembered).
     # Matches disclaimer_acceptance.CURRENT_VERSION when opted in on-device.
     "safety_disclaimer_version": 0,
+    # When True (default), lost-link / offline grace may open the setup hotspot.
+    # First-boot with no saved Wi-Fi still enters setup even when False.
+    "auto_wifi_setup_hotspot": True,
 }
 
 # Live preview while calibrating facing (not persisted until save).
@@ -2602,6 +2605,16 @@ def toggle_auto_idle_clock():
 
 def set_auto_idle_clock_enabled(enabled: bool):
     _state["auto_idle_clock"] = bool(enabled)
+    _save(_state)
+
+
+def auto_wifi_setup_hotspot_enabled() -> bool:
+    """True when lost-link may automatically open the Wi-Fi setup hotspot."""
+    return bool(_state.get("auto_wifi_setup_hotspot", True))
+
+
+def set_auto_wifi_setup_hotspot_enabled(enabled: bool) -> None:
+    _state["auto_wifi_setup_hotspot"] = bool(enabled)
     _save(_state)
 
 

--- a/flightscnr/tests/test_wifi_link.py
+++ b/flightscnr/tests/test_wifi_link.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+import tempfile
 import unittest
 from unittest import mock
 
@@ -128,6 +130,95 @@ class TestDownStreakHelper(unittest.TestCase):
             self.assertEqual(w.link_down_streak_needed(), 1)
         with mock.patch.object(w, "_LINK_DOWN_STREAK_N", 3):
             self.assertEqual(w.link_down_streak_needed(), 3)
+
+
+class TestAutoHotspotPreference(unittest.TestCase):
+    """Portal auto_wifi_setup_hotspot vs env skip (issue #127)."""
+
+    def setUp(self) -> None:
+        self._env = mock.patch.dict(os.environ, {}, clear=False)
+        self._env.start()
+        os.environ.pop("FLIGHTSCNR_SKIP_WIFI_SETUP", None)
+        os.environ.pop("FLIGHTSCNR_FORCE_WIFI_SETUP", None)
+
+    def tearDown(self) -> None:
+        self._env.stop()
+
+    def test_default_auto_hotspot_enabled(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=True):
+            self.assertTrue(w.auto_hotspot_enabled())
+
+    def test_portal_off_disables_auto_hotspot(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=False):
+            self.assertFalse(w.auto_hotspot_enabled())
+
+    def test_env_skip_disables_auto_hotspot(self) -> None:
+        os.environ["FLIGHTSCNR_SKIP_WIFI_SETUP"] = "1"
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=True):
+            self.assertFalse(w.auto_hotspot_enabled())
+            self.assertTrue(w.skip_requested())
+
+    def test_offline_entry_allowed_by_default(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=True):
+            with mock.patch.object(w, "link_up", return_value=False):
+                with mock.patch.object(w, "setup_mode_active", return_value=False):
+                    with mock.patch.object(w, "offline_grace_s", return_value=25.0):
+                        self.assertTrue(w.should_enter_setup_after_offline(30.0))
+                        self.assertFalse(w.should_enter_setup_after_offline(10.0))
+
+    def test_offline_entry_blocked_when_portal_auto_off(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=False):
+            with mock.patch.object(w, "link_up", return_value=False):
+                self.assertFalse(w.should_enter_setup_after_offline(999.0))
+
+    def test_boot_no_saved_still_enters_when_portal_auto_off(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=False):
+            with mock.patch.object(w, "link_up_blocking", return_value=False):
+                with mock.patch.object(w, "saved_client_wifi_names", return_value=[]):
+                    self.assertTrue(w.should_enter_setup_at_boot())
+
+    def test_boot_saved_offline_skipped_when_portal_auto_off(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=False):
+            with mock.patch.object(w, "link_up_blocking", return_value=False):
+                with mock.patch.object(
+                    w, "saved_client_wifi_names", return_value=["HomeWiFi"]
+                ):
+                    with mock.patch.object(w, "_wait_for_client_wifi") as wait:
+                        self.assertFalse(w.should_enter_setup_at_boot())
+                        wait.assert_not_called()
+
+    def test_boot_saved_offline_enters_when_portal_auto_on(self) -> None:
+        with mock.patch.object(w, "_portal_auto_wifi_setup_hotspot", return_value=True):
+            with mock.patch.object(w, "link_up_blocking", return_value=False):
+                with mock.patch.object(
+                    w, "saved_client_wifi_names", return_value=["HomeWiFi"]
+                ):
+                    with mock.patch.object(w, "offline_grace_s", return_value=5.0):
+                        with mock.patch.object(
+                            w, "_wait_for_client_wifi", return_value=False
+                        ):
+                            self.assertTrue(w.should_enter_setup_at_boot())
+
+    def test_env_skip_blocks_boot_even_without_saved(self) -> None:
+        os.environ["FLIGHTSCNR_SKIP_WIFI_SETUP"] = "true"
+        with mock.patch.object(w, "link_up_blocking", return_value=False):
+            with mock.patch.object(w, "saved_client_wifi_names", return_value=[]):
+                self.assertFalse(w.should_enter_setup_at_boot())
+
+    def test_request_enter_blocked_by_env_skip(self) -> None:
+        os.environ["FLIGHTSCNR_SKIP_WIFI_SETUP"] = "1"
+        self.assertFalse(w.request_enter_wifi_setup())
+
+    def test_request_and_consume_enter_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "wifi_setup_enter_request")
+            with mock.patch.object(w, "ENTER_REQUEST_PATH", path):
+                with mock.patch.object(w, "DATA_DIR", tmp):
+                    self.assertTrue(w.request_enter_wifi_setup())
+                    self.assertTrue(os.path.isfile(path))
+                    self.assertTrue(w.consume_enter_wifi_setup_request())
+                    self.assertFalse(os.path.isfile(path))
+                    self.assertFalse(w.consume_enter_wifi_setup_request())
 
 
 if __name__ == "__main__":

--- a/flightscnr/utilities/wifi_setup.py
+++ b/flightscnr/utilities/wifi_setup.py
@@ -51,6 +51,10 @@ CONNECTED_FLAG_PATH = os.path.join(DATA_DIR, "wifi_setup_connected")
 # Cross-process: portal/display is mid client-join — AP watchdog must stay out.
 JOIN_BUSY_PATH = os.path.join(DATA_DIR, "wifi_setup_joining")
 RADIO_LOCK_PATH = os.path.join(DATA_DIR, "wifi_setup_radio.lock")
+# Cross-process: portal/settings ask the display to enter Wi-Fi setup.
+ENTER_REQUEST_PATH = os.path.join(DATA_DIR, "wifi_setup_enter_request")
+# Portal preference file (same path as display.round_touch.settings.SETTINGS_PATH).
+_SETTINGS_JSON_PATH = os.path.join(DATA_DIR, "round_touch_settings.json")
 JOIN_BUSY_STALE_S = 180.0
 AP_CONNECTION_NAME = "flightscnr-setup-ap"
 AP_SSID_PREFIX = "FlightScnr-Setup"
@@ -132,6 +136,35 @@ def skip_requested() -> bool:
         "true",
         "yes",
     )
+
+
+def _portal_auto_wifi_setup_hotspot() -> bool:
+    """Read portal preference from round_touch_settings.json (default True).
+
+    Disk read avoids importing display.round_touch.settings (circular risk) and
+    works the same in the Flask child and the display process.
+    """
+    try:
+        with open(_SETTINGS_JSON_PATH, encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and "auto_wifi_setup_hotspot" in data:
+            return bool(data.get("auto_wifi_setup_hotspot"))
+    except FileNotFoundError:
+        pass
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug("Could not read auto_wifi_setup_hotspot", exc_info=True)
+    return True
+
+
+def auto_hotspot_enabled() -> bool:
+    """False when env skip is set or the portal auto-hotspot preference is off.
+
+    When False, lost-link / offline grace must not open the setup AP. First-boot
+    with no saved client Wi-Fi still enters setup (see should_enter_setup_at_boot).
+    """
+    if skip_requested():
+        return False
+    return _portal_auto_wifi_setup_hotspot()
 
 
 def force_requested() -> bool:
@@ -416,7 +449,9 @@ def should_enter_setup_at_boot() -> bool:
     """Boot-time decision, including fallback when a saved SSID is not found.
 
     If client Wi-Fi profiles exist but never associate (wrong place, AP off,
-    bad PSK), wait briefly for NetworkManager autoconnect, then enter setup.
+    bad PSK), wait briefly for NetworkManager autoconnect, then enter setup
+    unless the portal auto-hotspot preference (or env skip) disables that path.
+    No saved profiles still enters setup so first pairing always works.
     """
     if skip_requested():
         return False
@@ -426,6 +461,12 @@ def should_enter_setup_at_boot() -> bool:
         return False
     if not saved_client_wifi_names():
         return True
+    if not auto_hotspot_enabled():
+        logger.info(
+            "Saved Wi-Fi present but offline — auto setup hotspot disabled; "
+            "leaving NetworkManager to reconnect"
+        )
+        return False
     grace = offline_grace_s()
     logger.info(
         "Saved Wi-Fi present but not connected — waiting %.0fs before setup hotspot",
@@ -443,6 +484,8 @@ def should_enter_setup_after_offline(offline_s: float) -> bool:
         return False
     if force_requested():
         return True
+    if not _portal_auto_wifi_setup_hotspot():
+        return False
     if link_up():
         return False
     if setup_mode_active() and ap_radio_active():
@@ -482,6 +525,41 @@ def clear_wifi_connected_flag() -> None:
 
 def wifi_connect_signaled() -> bool:
     return os.path.isfile(CONNECTED_FLAG_PATH)
+
+
+def request_enter_wifi_setup() -> bool:
+    """Ask the display process to enter Wi-Fi setup (cross-process).
+
+    Returns False when env skip is set (admin override blocks manual entry too).
+    """
+    if skip_requested():
+        return False
+    os.makedirs(DATA_DIR, exist_ok=True)
+    tmp = ENTER_REQUEST_PATH + ".tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"at": time.time(), "pid": os.getpid()}, fh)
+        os.replace(tmp, ENTER_REQUEST_PATH)
+        return True
+    except OSError as exc:
+        logger.warning("Could not write Wi-Fi enter-setup request: %s", exc)
+        return False
+
+
+def clear_enter_wifi_setup_request() -> None:
+    try:
+        if os.path.isfile(ENTER_REQUEST_PATH):
+            os.unlink(ENTER_REQUEST_PATH)
+    except OSError:
+        pass
+
+
+def consume_enter_wifi_setup_request() -> bool:
+    """True once if a pending enter-setup request existed (clears the flag)."""
+    if not os.path.isfile(ENTER_REQUEST_PATH):
+        return False
+    clear_enter_wifi_setup_request()
+    return True
 
 
 def _pid_alive(pid: int) -> bool:

--- a/flightscnr/web/app.py
+++ b/flightscnr/web/app.py
@@ -321,6 +321,30 @@ def wifi_try_saved():
     ), code
 
 
+@app.post("/wifi/start-setup")
+def wifi_start_setup():
+    """Ask the display process to open the Wi-Fi setup hotspot (manual recovery)."""
+    from utilities import wifi_setup
+
+    if wifi_setup.skip_requested():
+        return jsonify(
+            {
+                "ok": False,
+                "message": "Wi-Fi setup is disabled by FLIGHTSCNR_SKIP_WIFI_SETUP.",
+            }
+        ), 400
+    if not wifi_setup.request_enter_wifi_setup():
+        return jsonify(
+            {"ok": False, "message": "Could not request Wi-Fi setup."}
+        ), 500
+    return jsonify(
+        {
+            "ok": True,
+            "message": "Opening Wi-Fi setup on the display…",
+        }
+    )
+
+
 @app.get("/")
 def index():
     if _wifi_portal_active():
@@ -894,6 +918,7 @@ def display_json():
             "lofi_volume": settings.lofi_volume(),
             "lofi_controls_enabled": settings.lofi_controls_enabled(),
             "lofi_title_scroll": settings.lofi_title_scroll(),
+            "auto_wifi_setup_hotspot": settings.auto_wifi_setup_hotspot_enabled(),
         }
     )
 
@@ -995,6 +1020,11 @@ def display_save():
         settings.set_lofi_controls_enabled(bool(data.get("lofi_controls_enabled")))
     if "lofi_title_scroll" in data:
         settings.set_lofi_title_scroll(bool(data.get("lofi_title_scroll")))
+    if "auto_wifi_setup_hotspot" in data:
+        settings.set_auto_wifi_setup_hotspot_enabled(
+            bool(data.get("auto_wifi_setup_hotspot"))
+        )
+        settings.request_reload()
     return jsonify(
         {
             "ok": True,
@@ -1028,6 +1058,7 @@ def display_save():
             "lofi_volume": settings.lofi_volume(),
             "lofi_controls_enabled": settings.lofi_controls_enabled(),
             "lofi_title_scroll": settings.lofi_title_scroll(),
+            "auto_wifi_setup_hotspot": settings.auto_wifi_setup_hotspot_enabled(),
             "message": "Display settings saved.",
         }
     )

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -970,8 +970,18 @@
     </details>
 
     <details class="card system-card">
-        <summary><span class="ico">&#9881;</span>System<span class="sum">power</span><span class="chev">&#9656;</span></summary>
+        <summary><span class="ico">&#9881;</span>System<span class="sum">power, Wi-Fi</span><span class="chev">&#9656;</span></summary>
         <div class="body">
+            <p class="hint">When enabled (default), FlightScnr opens the setup hotspot if the network stays down past a short grace period. Turn this off on mesh or always-on Wi-Fi so NetworkManager can keep reconnecting. First-time setup with no saved Wi-Fi still uses the QR hotspot. Use <strong>Start Wi-Fi setup</strong> for recovery.</p>
+            <div class="chk">
+                <label for="auto_wifi_setup_hotspot">Automatic Wi-Fi setup hotspot</label>
+                <span class="switch"><input id="auto_wifi_setup_hotspot" type="checkbox" checked><span class="track"></span></span>
+            </div>
+            <div class="track-row" style="margin-top:.55rem">
+                <button class="btn btn-primary" id="btn-wifi-start-setup" type="button">Start Wi-Fi setup</button>
+            </div>
+            <div id="wifi-setup-pref-status" class="status"></div>
+            <hr style="border:none;border-top:1px solid var(--line, #333);margin:1rem 0">
             <p class="hint">Download a backup of portal preferences (radar, display, alerts, weather, off-hours, favourites, location, ATC, and API keys). The file includes secrets — keep it private. Does not include maps, photos, or <code>/etc/flightscnr.env</code>.</p>
             <div class="track-row" style="margin-top:.55rem">
                 <button class="btn btn-primary" id="btn-export-settings" type="button">Download settings</button>
@@ -1029,7 +1039,7 @@
     </details>
 
 
-    <p class="wifi-note">First-time Wi-Fi uses the on-device QR setup hotspot when no network is configured.</p>
+    <p class="wifi-note">First-time Wi-Fi uses the on-device QR setup hotspot when no network is configured. Automatic hotspot after a lost link can be changed under System.</p>
     <p class="foot">
         <a href="/stats">Statistics</a> ·
         <a href="/closest">Closest map</a> ·
@@ -1522,6 +1532,9 @@ async function loadAll() {
             $("lofi_volume").value = String(d.lofi_volume ?? 25);
             const ll = $("lofi_volume_label");
             if (ll) ll.textContent = `${$("lofi_volume").value}%`;
+        }
+        if ($("auto_wifi_setup_hotspot")) {
+            $("auto_wifi_setup_hotspot").checked = d.auto_wifi_setup_hotspot !== false;
         }
         syncChimeVolumeLabel();
     } catch (_) {}
@@ -2144,6 +2157,7 @@ async function saveAndReloadSettings(statusId) {
                 lofi_volume: $("lofi_volume") ? Number($("lofi_volume").value) : 25,
                 lofi_controls_enabled: $("lofi_controls_enabled") ? $("lofi_controls_enabled").checked : false,
                 lofi_title_scroll: $("lofi_title_scroll") ? $("lofi_title_scroll").checked : true,
+                auto_wifi_setup_hotspot: $("auto_wifi_setup_hotspot") ? $("auto_wifi_setup_hotspot").checked : true,
             }),
         });
         const loc = ($("radar_center").value || "").trim();
@@ -2942,6 +2956,43 @@ if ($("hide_update_banner")) {
 }
 if ($("auto_update_time")) {
     $("auto_update_time").addEventListener("change", saveAutoUpdatePrefs);
+}
+if ($("auto_wifi_setup_hotspot")) {
+    $("auto_wifi_setup_hotspot").addEventListener("change", async () => {
+        clearStatus("wifi-setup-pref-status");
+        try {
+            const data = await jsonFetch("/display", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    auto_wifi_setup_hotspot: $("auto_wifi_setup_hotspot").checked,
+                }),
+            });
+            showStatus(
+                "wifi-setup-pref-status",
+                data.auto_wifi_setup_hotspot !== false
+                    ? "Automatic Wi-Fi setup hotspot is on."
+                    : "Automatic Wi-Fi setup hotspot is off — NetworkManager will keep trying to reconnect."
+            );
+        } catch (e) {
+            showStatus("wifi-setup-pref-status", e.message, true);
+            $("auto_wifi_setup_hotspot").checked = !$("auto_wifi_setup_hotspot").checked;
+        }
+    });
+}
+if ($("btn-wifi-start-setup")) {
+    $("btn-wifi-start-setup").addEventListener("click", async () => {
+        clearStatus("wifi-setup-pref-status");
+        try {
+            const data = await jsonFetch("/wifi/start-setup", { method: "POST" });
+            showStatus(
+                "wifi-setup-pref-status",
+                data.message || "Opening Wi-Fi setup on the display…"
+            );
+        } catch (e) {
+            showStatus("wifi-setup-pref-status", e.message, true);
+        }
+    });
 }
 $("btn-repair-update").addEventListener("click", applyRepairConfirmed);
 $("btn-resync-install").addEventListener("click", applyResyncConfirmed);


### PR DESCRIPTION
## Summary
- Expose **Automatic Wi-Fi setup hotspot** in the Web Portal (System), default on — uses existing `FLIGHTSCNR_SKIP_WIFI_SETUP` / lost-link grace behavior
- When off, leave NetworkManager to reconnect after link loss; first-boot with no saved Wi-Fi still opens the QR setup hotspot
- Add **Start Wi-Fi setup** (portal + device Settings → System) for manual recovery

Closes #127

## Test plan
- [x] `pytest tests/test_wifi_link.py tests/test_disclaimer_acceptance.py -q`
- [ ] Portal System: toggle off; with saved Wi-Fi, lose link → no auto setup AP
- [ ] First boot / no saved Wi-Fi still enters setup when toggle is off
- [ ] Start Wi-Fi setup still works when auto is off; blocked when `FLIGHTSCNR_SKIP_WIFI_SETUP=1`
- [ ] Default (toggle on) keeps prior auto-hotspot behavior


Made with [Cursor](https://cursor.com)