### PR TITLE
Fix ATC disconnect loop and off-hours display off

### DIFF
--- a/flightscnr/display/round_touch/app.py
+++ b/flightscnr/display/round_touch/app.py
@@ -342,11 +342,12 @@ class RoundTouchDisplay:
         self._safe_draw()
 
     def _migrate_off_hours_dim(self) -> None:
-        """One-time fold: legacy off-hours dim/off becomes quiet-hours dim.
+        """One-time fold: copy legacy off-hours dim into quiet-hours dim too.
 
-        Off-hours no longer touches brightness. Anyone who had night
-        dimming (the old default) keeps the same behavior through quiet
-        dim — the quiet window already defaults to the off-hours window.
+        Off-hours dim/off still drives brightness on its own schedule.
+        Quiet dim remains available for the ATC quiet-hours window; devices
+        that only had off-hours night dimming also get quiet dim seeded once
+        so both UIs stay consistent.
         """
         try:
             if bool(settings._state.get("quiet_dim_migrated", False)):

--- a/flightscnr/display/round_touch/off_hours.py
+++ b/flightscnr/display/round_touch/off_hours.py
@@ -214,8 +214,19 @@ def in_night_window(now: datetime | None = None) -> bool:
 
 
 def effective_brightness_percent(day_percent: int) -> int:
-    """Off-hours no longer changes brightness — display dimming is the
-    quiet-hours dim feature (Settings → Quiet). Off-hours keeps its
-    schedule for the night-clock behavior only. Legacy dim/off prefs
-    migrate to quiet dim on startup."""
+    """Brightness during the off-hours window (dim / turn-off / legacy clock).
+
+    Quiet-hours dim (Settings → Quiet) can still darken further when ATC
+    quiet hours are active; both schedules may apply via ``min()``.
+    """
+    if in_off_hours():
+        cfg = prefs()
+        mode = str(cfg.get("mode", "dim")).lower()
+        if mode == "off":
+            return 0
+        if mode == "clock":
+            # Legacy: full day brightness while on clock.
+            return clamp_brightness_percent(int(day_percent))
+        # dim (and dim + force_clock): use configured night dim level.
+        return clamp_brightness_percent(int(cfg.get("dim_percent", 20)))
     return day_percent

--- a/flightscnr/tests/test_atc_audio.py
+++ b/flightscnr/tests/test_atc_audio.py
@@ -666,6 +666,49 @@ class PlayerTests(unittest.TestCase):
             atc_audio.reconcile_enabled_state()
         stop.assert_called_once_with(clear_override=False)
 
+    def test_keepalive_syncs_disk_before_stale_reconcile(self):
+        """Portal memory can lag disk; sync before killing a live stream."""
+        from utilities import atc_audio
+
+        self.settings.atc_enabled.return_value = False
+        self.settings.atc_want_playing.return_value = False
+
+        def _sync():
+            self.settings.atc_enabled.return_value = True
+            self.settings.atc_want_playing.return_value = True
+
+        self.settings.sync_from_disk.side_effect = _sync
+        self.settings.atc_airport.return_value = "KSFO"
+        with mock.patch.object(atc_audio, "is_playing", return_value=True), mock.patch.object(
+            atc_audio, "reconcile_enabled_state"
+        ) as reconcile, mock.patch.object(atc_audio, "start") as start:
+            st = atc_audio.maybe_keepalive()
+        reconcile.assert_not_called()
+        start.assert_not_called()
+        self.assertTrue(st.get("playing") or "playing" in st)
+        self.settings.sync_from_disk.assert_called()
+
+    def test_reconcile_syncs_disk_before_stopping(self):
+        from utilities import atc_audio
+
+        self.settings.atc_enabled.return_value = False
+        self.settings.atc_want_playing.return_value = False
+
+        def _sync():
+            self.settings.atc_enabled.return_value = True
+            self.settings.atc_want_playing.return_value = True
+
+        self.settings.sync_from_disk.side_effect = _sync
+        with mock.patch.object(atc_audio, "is_playing", return_value=True), mock.patch.object(
+            atc_audio, "stop", return_value={"playing": False}
+        ) as stop, mock.patch.object(
+            atc_audio, "status", return_value={"playing": True}
+        ):
+            st = atc_audio.reconcile_enabled_state()
+        stop.assert_not_called()
+        self.assertTrue(st["playing"])
+        self.settings.sync_from_disk.assert_called()
+
     def test_set_volume_uses_ipc_when_playing(self):
         from utilities import atc_audio
 

--- a/flightscnr/tests/test_off_hours_clock_nav.py
+++ b/flightscnr/tests/test_off_hours_clock_nav.py
@@ -105,8 +105,8 @@ class TestOffHoursClockNav(unittest.TestCase):
         self.assertEqual(d._opened, [])
         self.assertFalse(d._off_hours_force_clock_active)
 
-    def test_off_hours_does_not_change_brightness(self):
-        """Night dimming lives on Quiet Hours; off-hours only drives the clock."""
+    def test_off_hours_dim_and_off_change_brightness(self):
+        """Off-hours schedule still dims or blanks the panel on its window."""
         d = _bare_display()
         d.screen = app_mod.SCREEN_RADAR
         applied = []
@@ -115,10 +115,10 @@ class TestOffHoursClockNav(unittest.TestCase):
             "display.round_touch.off_hours.in_off_hours", return_value=True
         ), mock.patch(
             "display.round_touch.off_hours.effective_brightness_percent",
-            side_effect=lambda day: day,
+            return_value=0,
         ), mock.patch(
             "display.round_touch.off_hours.prefs",
-            return_value={"mode": "clock"},
+            return_value={"mode": "off"},
         ), mock.patch(
             "display.round_touch.settings.brightness_percent", return_value=80
         ), mock.patch(
@@ -127,18 +127,17 @@ class TestOffHoursClockNav(unittest.TestCase):
             "display.round_touch.backlight.apply_percent", side_effect=applied.append
         ):
             d._apply_brightness()
-        self.assertEqual(applied, [80])
+        self.assertEqual(applied, [0])
 
-        d.screen = app_mod.SCREEN_CLOCK
         applied.clear()
         with mock.patch(
             "display.round_touch.off_hours.in_off_hours", return_value=True
         ), mock.patch(
             "display.round_touch.off_hours.effective_brightness_percent",
-            side_effect=lambda day: day,
+            return_value=12,
         ), mock.patch(
             "display.round_touch.off_hours.prefs",
-            return_value={"mode": "clock"},
+            return_value={"mode": "dim", "dim_percent": 12},
         ), mock.patch(
             "display.round_touch.settings.brightness_percent", return_value=80
         ), mock.patch(
@@ -147,7 +146,33 @@ class TestOffHoursClockNav(unittest.TestCase):
             "display.round_touch.backlight.apply_percent", side_effect=applied.append
         ):
             d._apply_brightness()
-        self.assertEqual(applied, [80])
+        self.assertEqual(applied, [12])
+
+
+class TestOffHoursBrightness(unittest.TestCase):
+    def test_effective_brightness_off_and_dim(self):
+        from display.round_touch import off_hours
+
+        with mock.patch.object(
+            off_hours, "in_off_hours", return_value=True
+        ), mock.patch.object(
+            off_hours,
+            "prefs",
+            return_value={"mode": "off", "dim_percent": 20},
+        ):
+            self.assertEqual(off_hours.effective_brightness_percent(80), 0)
+
+        with mock.patch.object(
+            off_hours, "in_off_hours", return_value=True
+        ), mock.patch.object(
+            off_hours,
+            "prefs",
+            return_value={"mode": "dim", "dim_percent": 15},
+        ):
+            self.assertEqual(off_hours.effective_brightness_percent(80), 15)
+
+        with mock.patch.object(off_hours, "in_off_hours", return_value=False):
+            self.assertEqual(off_hours.effective_brightness_percent(80), 80)
 
 
 if __name__ == "__main__":

--- a/flightscnr/utilities/atc_audio.py
+++ b/flightscnr/utilities/atc_audio.py
@@ -936,6 +936,19 @@ def _settings():
     return settings
 
 
+def _sync_settings_from_disk() -> None:
+    """Reload ATC intent from disk before cross-process start/stop decisions.
+
+    Display and portal each cache settings in memory. The portal speaker-watch
+    only synced on HTTP requests, so a stale enabled=False/want=False could
+    reconcile-kill mpv that the display keepalive just started.
+    """
+    try:
+        _settings().sync_from_disk()
+    except Exception:
+        logger.debug("ATC settings sync_from_disk failed", exc_info=True)
+
+
 def _prefs() -> dict:
     settings = _settings()
     return {
@@ -1488,6 +1501,7 @@ def maybe_resume_when_speaker_ready() -> dict:
     Used by the USB-speaker watch thread. Does not clear ``want_playing`` when
     the speaker is still missing — that is handled by ``start()`` deferral.
     """
+    _sync_settings_from_disk()
     settings = _settings()
     if not settings.atc_enabled() or not settings.atc_want_playing():
         return status()
@@ -1515,6 +1529,7 @@ def reconcile_enabled_state() -> dict:
     (especially if the IPC socket was already unlinked). Call from the speaker
     watch and after settings reload so orphans cannot outlive the UI toggle.
     """
+    _sync_settings_from_disk()
     settings = _settings()
     if settings.atc_enabled() and settings.atc_want_playing():
         return status()
@@ -1536,6 +1551,7 @@ def maybe_keepalive() -> dict:
     """
     global _keepalive_next_at, _keepalive_failures
 
+    _sync_settings_from_disk()
     settings = _settings()
     if not settings.atc_enabled() or not settings.atc_want_playing():
         _keepalive_failures = 0

--- a/flightscnr/web/templates/index.html
+++ b/flightscnr/web/templates/index.html
@@ -737,6 +737,15 @@
                 <label for="night_en">Enable off-hours (night mode)</label>
                 <span class="switch"><input id="night_en" type="checkbox"><span class="track"></span></span>
             </div>
+            <label for="night_mode">During off-hours</label>
+            <select id="night_mode">
+                <option value="dim">Dim display</option>
+                <option value="off">Turn off display</option>
+            </select>
+            <div id="dim-row">
+                <label for="night_dim">Dim brightness <span id="night_dim_label">20%</span></label>
+                <input id="night_dim" type="range" min="3" max="100" step="1" value="20" oninput="syncNightDimLabel()">
+            </div>
             <div class="chk">
                 <label for="night_clock">Show clock during off-hours</label>
                 <span class="switch"><input id="night_clock" type="checkbox"><span class="track"></span></span>
@@ -745,7 +754,7 @@
                 <div><label for="night_start">Start</label><input type="time" id="night_start"></div>
                 <div><label for="night_end">End</label><input type="time" id="night_end"></div>
             </div>
-            <p class="note">Off-hours controls the night-clock schedule. Display dimming (down to 0% = screen off) lives under Display, screens &amp; volume &rarr; "Dim during quiet hours", which follows the ATC quiet-hours window.</p>
+            <p class="note">Dim/off and clock can be combined — e.g. turn the display off (or dim it) and still force the clock screen. Quiet-hours dim under Display is a separate schedule tied to ATC quiet hours.</p>
             <button class="btn btn-primary" id="btn-offhours" style="margin-top:.7rem" type="button">Save off-hours</button>
             <div id="offhours-status" class="status"></div>
         </div>
@@ -1544,8 +1553,10 @@ async function loadAll() {
         $("night_en").checked = !!o.enabled;
         let mode = (o.mode || "dim");
         if (mode === "clock") mode = "dim";
+        if ($("night_mode")) $("night_mode").value = (mode === "off") ? "off" : "dim";
         $("night_start").value = o.start || "22:00";
         $("night_end").value = o.end || "06:00";
+        if ($("night_dim")) $("night_dim").value = String(o.dim_percent ?? 20);
         syncNightDimLabel();
         if ($("night_clock")) $("night_clock").checked = !!o.force_clock || (o.mode === "clock");
         toggleDimRow();
@@ -1629,6 +1640,9 @@ async function loadAll() {
 }
 
 function toggleDimRow() {
+    const mode = $("night_mode") ? $("night_mode").value : "dim";
+    const row = $("dim-row");
+    if (row) row.style.display = mode === "dim" ? "" : "none";
 }
 
 function syncBrightLabel() {
@@ -1636,6 +1650,8 @@ function syncBrightLabel() {
     if (el) el.textContent = `${$("bright_pct").value}%`;
 }
 function syncNightDimLabel() {
+    const el = $("night_dim_label");
+    if (el && $("night_dim")) el.textContent = `${$("night_dim").value}%`;
 }
 function syncHudOpacityLabel() {
     const el = $("radar_hud_opacity_label");
@@ -2187,6 +2203,8 @@ async function saveOffHours() {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
                 enabled: $("night_en").checked,
+                mode: $("night_mode") ? $("night_mode").value : "dim",
+                dim_percent: $("night_dim") ? Number($("night_dim").value) : 20,
                 force_clock: $("night_clock") ? $("night_clock").checked : false,
                 start: $("night_start").value,
                 end: $("night_end").value,
@@ -3071,6 +3089,9 @@ $("btn-position-sources-reset").addEventListener("click", resetPositionSources);
 $("btn-save-reload").addEventListener("click", () => saveAndReloadSettings("display-status"));
 $("btn-save-lofi").addEventListener("click", () => saveAndReloadSettings("lofi-status"));
 $("btn-offhours").addEventListener("click", saveOffHours);
+if ($("night_mode")) {
+    $("night_mode").addEventListener("change", toggleDimRow);
+}
 $("btn-weather").addEventListener("click", saveWeather);
 $("btn-weather-fetch").addEventListener("click", fetchWeatherNow);
 $("btn-alerts").addEventListener("click", saveAlerts);


### PR DESCRIPTION
## Summary
- Fix ATC start/stop fight: sync settings from disk before keepalive/reconcile so the portal cannot kill a stream the display just started.
- Restore off-hours dim / turn-off display brightness and portal controls (decoupled from ATC quiet-hours dim).